### PR TITLE
Detect OS. If Linux, modify LDFLAGS.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,12 @@ NETCDF_INCLUDEDIR=/opt/local/include
 NETCDF_LIBDIR=/opt/local/lib
 
 # Library files to include
-LDFILES= -lnetcdf -lnetcdf_c++ -framework accelerate
+UNAME=$(shell uname)
+ifeq ($(UNAME), Linux)
+	LDFILES= -lnetcdf_c++ -lnetcdf -llapack -lblas -Wl,-rpath=${NETCDF_LIBDIR}
+else
+	LDFILES= -lnetcdf -lnetcdf_c++ -framework accelerate
+endif
 
 ##############################################################################
 # DO NOT MODIFY BELOW THIS LINE


### PR DESCRIPTION
Lapack and blas are needed by LinearRemapFV/SE0.

The -Wl,-rpath part puts the netcdf .so files into the shared lib path at
runtime.

Remove -framework, as that seems specific to Mac OS.

Do something different only if uname gives Linux; otherwise, do the same as
before.