### PR TITLE
Adding area correction synchronized with homme

### DIFF
--- a/src/CalculateDiffNorms.cpp
+++ b/src/CalculateDiffNorms.cpp
@@ -53,7 +53,8 @@ try {
 	int nP;
 
 	// Use bubble function
-	bool fBubble;
+	bool fBubble_uniform;
+	bool fBubble_interior;
 
 	// Output filename
 	std::string strOutputFile;
@@ -65,7 +66,10 @@ try {
 		CommandLineString(strVariableName, "var", "Psi");
 		CommandLineBool(fGLL, "gll");
 		CommandLineInt(nP, "np", 4);
-		CommandLineBool(fBubble, "bubble");
+		//fBubble_uniform is for old bubble correction,
+		//fBubble_interior is for homme 'epsilon-bubble correction'
+		CommandLineBool(fBubble_uniform, "bubble-uniform");
+		CommandLineBool(fBubble_interior, "bubble-interior");
 		CommandLineString(strMeshFile, "mesh", "");
 		CommandLineString(strOutputFile, "outfile", "");
 
@@ -146,7 +150,7 @@ try {
 		DataMatrix3D<int> dataGLLnodes;
 		DataMatrix3D<double> dataGLLJacobian;
 
-		GenerateMetaData(mesh, nP, fBubble, dataGLLnodes, dataGLLJacobian);
+		GenerateMetaData(mesh, nP, fBubble_uniform, fBubble_interior, dataGLLnodes, dataGLLJacobian);
 
 		GenerateUniqueJacobian(
 			dataGLLnodes, dataGLLJacobian, dataUniqueJacobian);

--- a/src/FiniteElementTools.h
+++ b/src/FiniteElementTools.h
@@ -83,7 +83,7 @@ void ApplyInverseMap(
 double GenerateMetaData(
 	const Mesh & mesh,
 	int nP,
-	bool fBubble,
+	int fBubble,
 	DataMatrix3D<int> & dataGLLnodes,
 	DataMatrix3D<double> & dataGLLJacobian
 );

--- a/src/FiniteElementTools.h
+++ b/src/FiniteElementTools.h
@@ -83,7 +83,8 @@ void ApplyInverseMap(
 double GenerateMetaData(
 	const Mesh & mesh,
 	int nP,
-	int fBubble,
+    bool fBubble_uniform,
+	bool fBubble_interior,
 	DataMatrix3D<int> & dataGLLnodes,
 	DataMatrix3D<double> & dataGLLJacobian
 );

--- a/src/GenerateGLLMetaData.cpp
+++ b/src/GenerateGLLMetaData.cpp
@@ -37,7 +37,7 @@ try {
 	int nP;
 
 	// Use of bubble to adjust areas
-	bool fBubble;
+	int fBubble;
 
 	// Output metadata file
 	std::string strOutput;

--- a/src/GenerateGLLMetaData.cpp
+++ b/src/GenerateGLLMetaData.cpp
@@ -37,7 +37,8 @@ try {
 	int nP;
 
 	// Use of bubble to adjust areas
-	int fBubble;
+	bool fBubble_uniform;
+	bool fBubble_interior;
 
 	// Output metadata file
 	std::string strOutput;
@@ -78,7 +79,8 @@ try {
 		GenerateMetaData(
 			meshInput,
 			nP,
-			fBubble,
+			fBubble_uniform,
+			fBubble_interior,
 			dataGLLnodes,
 			dataGLLJacobian
 		);

--- a/src/GenerateOfflineMap.cpp
+++ b/src/GenerateOfflineMap.cpp
@@ -157,8 +157,11 @@ try {
 	// Order of polynomial in each output element
 	int nPout;
 
+	// Use bubble on all spectral element nodes
+	bool fBubble_uniform;
+	
 	// Use bubble on interior of spectral element nodes
-	int fBubble;
+	bool fBubble_interior;
 
 	// Enforce monotonicity
 	bool fMonotoneType1;
@@ -220,10 +223,10 @@ try {
 		CommandLineStringD(strOutputType, "out_type", "fv", "[fv|cgll|dgll]");
 		CommandLineInt(nPin, "in_np", 4);
 		CommandLineInt(nPout, "out_np", 4);
-		//0 for no bubble correction,
-		//1 for old bubble correction,
-		//2 is for homme 'epsilon-bubble correction'
-		CommandLineInt(fBubble, "bubble",0);
+		//fBubble_uniform is for old bubble correction,
+		//fBubble_interior is for homme 'epsilon-bubble correction'
+		CommandLineBool(fBubble_uniform, "bubble-uniform");
+		CommandLineBool(fBubble_interior, "bubble-interior");
 		CommandLineBool(fMonotoneType1, "mono");
 		CommandLineBool(fMonotoneType2, "mono2");
 		CommandLineBool(fMonotoneType3, "mono3");
@@ -273,7 +276,11 @@ try {
 	if ((strOutputMeta != "") && (strOutputType == "fv")) {
 		_EXCEPTIONT("--out_meta cannot be used with --out_type fv");
 	}
-
+	
+	if ( fBubble_interior && fBubble_uniform) {
+		_EXCEPTIONT("Cannot use both bubble-uniform and bubble-interior options, use only one.");
+	}
+	
 	// Check command line parameters (data type arguments)
 	STLStringHelper::ToLower(strInputType);
 	STLStringHelper::ToLower(strOutputType);
@@ -492,7 +499,8 @@ try {
 				GenerateMetaData(
 					meshOutput,
 					nPout,
-					fBubble,
+					fBubble_uniform,
+					fBubble_interior,
 					dataGLLNodes,
 					dataGLLJacobian);
 
@@ -575,7 +583,8 @@ try {
 				GenerateMetaData(
 					meshInput,
 					nPin,
-					fBubble,
+					fBubble_uniform,
+					fBubble_interior,
 					dataGLLNodes,
 					dataGLLJacobian);
 
@@ -657,7 +666,8 @@ try {
 				GenerateMetaData(
 					meshInput,
 					nPin,
-					fBubble,
+					fBubble_uniform,
+					fBubble_interior,
 					dataGLLNodesIn,
 					dataGLLJacobianIn);
 
@@ -683,7 +693,8 @@ try {
 				GenerateMetaData(
 					meshOutput,
 					nPout,
-					fBubble,
+					fBubble_uniform,
+					fBubble_interior,
 					dataGLLNodesOut,
 					dataGLLJacobianOut);
 

--- a/src/GenerateOfflineMap.cpp
+++ b/src/GenerateOfflineMap.cpp
@@ -158,7 +158,7 @@ try {
 	int nPout;
 
 	// Use bubble on interior of spectral element nodes
-	bool fBubble;
+	int fBubble;
 
 	// Enforce monotonicity
 	bool fMonotoneType1;
@@ -220,7 +220,10 @@ try {
 		CommandLineStringD(strOutputType, "out_type", "fv", "[fv|cgll|dgll]");
 		CommandLineInt(nPin, "in_np", 4);
 		CommandLineInt(nPout, "out_np", 4);
-		CommandLineBool(fBubble, "bubble");
+		//0 for no bubble correction,
+		//1 for old bubble correction,
+		//2 is for homme 'epsilon-bubble correction'
+		CommandLineInt(fBubble, "bubble",0);
 		CommandLineBool(fMonotoneType1, "mono");
 		CommandLineBool(fMonotoneType2, "mono2");
 		CommandLineBool(fMonotoneType3, "mono3");

--- a/src/GenerateOfflineMap_v1.cpp
+++ b/src/GenerateOfflineMap_v1.cpp
@@ -139,9 +139,12 @@ try {
 	// Order of polynomial in each output element
 	int nPout;
 
-	// Use bubble on interior of spectral element nodes
-	int fBubble;
-
+	// Use bubble on all spectral element nodes
+	bool fBubble_uniform;
+	
+	// Use bubble on only interior of spectral element nodes
+	bool fBubble_interior;
+	
 	// Enforce monotonicity
 	bool fMonotone;
 
@@ -189,10 +192,10 @@ try {
 		CommandLineStringD(strOutputType, "out_type", "fv", "[fv|cgll|dgll]");
 		CommandLineInt(nPin, "in_np", 4);
 		CommandLineInt(nPout, "out_np", 4);
-		//0 for no bubble correction,
-		//1 for old bubble correction,
-		//2 is for homme 'epsilon-bubble correction'
-		CommandLineInt(fBubble, "bubble", 0);
+		//fBubble_uniform is for old bubble correction,
+		//fBubble_interior is for homme 'epsilon-bubble correction'
+		CommandLineBool(fBubble_uniform, "bubble-uniform");
+		CommandLineBool(fBubble_interior, "bubble-interior");
 		CommandLineBool(fMonotone, "mono");
 		CommandLineBool(fNoCheck, "nocheck");
 		CommandLineString(strVariables, "var", "");
@@ -229,6 +232,10 @@ try {
 		_EXCEPTIONT("out_data specified without in_data");
 	}
 
+	if ( fBubble_interior && fBubble_uniform) {
+		_EXCEPTIONT("Cannot use both bubble-uniform and bubble-interior options, use only one.");
+	}
+	
 	// Check command line parameters (data type arguments)
 	STLStringHelper::ToLower(strInputType);
 	STLStringHelper::ToLower(strOutputType);

--- a/src/GenerateOfflineMap_v1.cpp
+++ b/src/GenerateOfflineMap_v1.cpp
@@ -140,7 +140,7 @@ try {
 	int nPout;
 
 	// Use bubble on interior of spectral element nodes
-	bool fBubble;
+	int fBubble;
 
 	// Enforce monotonicity
 	bool fMonotone;
@@ -189,7 +189,10 @@ try {
 		CommandLineStringD(strOutputType, "out_type", "fv", "[fv|cgll|dgll]");
 		CommandLineInt(nPin, "in_np", 4);
 		CommandLineInt(nPout, "out_np", 4);
-		CommandLineBool(fBubble, "bubble");
+		//0 for no bubble correction,
+		//1 for old bubble correction,
+		//2 is for homme 'epsilon-bubble correction'
+		CommandLineInt(fBubble, "bubble", 0);
 		CommandLineBool(fMonotone, "mono");
 		CommandLineBool(fNoCheck, "nocheck");
 		CommandLineString(strVariables, "var", "");

--- a/src/GenerateTestData.cpp
+++ b/src/GenerateTestData.cpp
@@ -430,7 +430,7 @@ try {
 		DataMatrix3D<int> dataGLLNodes;
 		DataMatrix3D<double> dataGLLJacobian;
 
-		GenerateMetaData(mesh, nP, false, dataGLLNodes, dataGLLJacobian);
+		GenerateMetaData(mesh, nP, false, false, dataGLLNodes, dataGLLJacobian);
 
 		// Number of elements
 		int nElements = mesh.faces.size();


### PR DESCRIPTION
Adding an option to correct area the same way as homme does in epsilon-bubble correction -- by redistributing area difference among inner nodes.

I need to clean up a few printstatements and test this, but let me know if there are any bigger issues.
