### PR TITLE
Update the blas configuration to support Intel MKL when available

### DIFF
--- a/config/ax_blas.m4
+++ b/config/ax_blas.m4
@@ -164,7 +164,37 @@ fi
 
 # BLAS in Intel MKL library?
 if test $ax_blas_ok = no; then
-  AC_CHECK_LIB(mkl, $sgemm, [ax_blas_ok=yes;BLAS_LIBS="-lmkl"])
+  # MKL for gfortran
+  if test x"$ac_cv_fc_compiler_gnu" = xyes; then
+    # 64 bit
+    if test $host_cpu = x86_64; then
+      AC_CHECK_LIB(mkl_gf_lp64, $sgemm,
+      [ax_blas_ok=yes;BLAS_LIBS="-lmkl_gf_lp64 -lmkl_sequential -lmkl_core -lpthread"],,
+      [-lmkl_gf_lp64 -lmkl_sequential -lmkl_core -lpthread])
+    # 32 bit
+    elif test $host_cpu = i686; then
+      AC_CHECK_LIB(mkl_gf, $sgemm,
+        [ax_blas_ok=yes;BLAS_LIBS="-lmkl_gf -lmkl_sequential -lmkl_core -lpthread"],,
+        [-lmkl_gf -lmkl_sequential -lmkl_core -lpthread])
+    fi
+  # MKL for other compilers (Intel, PGI, ...?)
+  else
+    # 64-bit
+    if test $host_cpu = x86_64; then
+      AC_CHECK_LIB(mkl_intel_lp64, $sgemm,
+        [ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread"],,
+        [-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread])
+    # 32-bit
+    elif test $host_cpu = i686; then
+      AC_CHECK_LIB(mkl_intel, $sgemm,
+        [ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel -lmkl_sequential -lmkl_core -lpthread"],,
+        [-lmkl_intel -lmkl_sequential -lmkl_core -lpthread])
+    fi
+  fi
+fi
+# Old versions of MKL
+if test $ax_blas_ok = no; then
+  AC_CHECK_LIB(mkl, $sgemm, [ax_blas_ok=yes;BLAS_LIBS="-lmkl -lguide -lpthread"],,[-lguide -lpthread])
 fi
 
 # BLAS in Apple vecLib library?


### PR DESCRIPTION
Let me know if this provides the right configurations on Yellowstone. If the MKL directory is part of LD_LIBRARY_PATH, it should pick things up. Tested on Blues/LCRC/ANL with Intel 15.0/MKL 11.2.

I did not test Intel+OSX. I don't have that combination available for testing locally.