### PR TITLE
Add the older build system to complement Autoconf

### DIFF
--- a/Makefile.gmake
+++ b/Makefile.gmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2016      Bryce Adelstein-Lelbach aka wash
+# Copyright (c) 2000-2016 Paul Ullrich 
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+BUILD_TARGETS= src/
+CLEAN_TARGETS= $(addsuffix .clean,$(BUILD_TARGETS))
+
+.PHONY: all clean $(BUILD_TARGETS) $(CLEAN_TARGETS)
+
+# Build rules.
+all: $(BUILD_TARGETS)
+
+$(BUILD_TARGETS): %:
+	@cd $*; $(MAKE) -f Makefile.gmake
+
+# Clean rules.
+clean: $(CLEAN_TARGETS)
+	@rm -f bin/*
+
+$(CLEAN_TARGETS): %.clean:
+	@cd $*; $(MAKE) -f Makefile.gmake clean
+
+# DO NOT DELETE

--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ You will likely need to edit the first couple lines of the Makefile to
 customize the NetCDF paths and change any compiler flags.  Once you have
 modified the Makefile, build the code:
 
-make all
+`make -f Makefile.gmake all`
+
+To clean out the object file and return the sources to pristine condition,
+you can execute the following:
+
+`make -f Makefile.gmake clean`
 
 Mesh Generation
 ---------------

--- a/src/Makefile.gmake
+++ b/src/Makefile.gmake
@@ -1,0 +1,82 @@
+# Copyright (c) 2016      Bryce Adelstein-Lelbach aka wash
+# Copyright (c) 2000-2016 Paul Ullrich 
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Base directory.
+TEMPESTREMAPDIR=..
+
+# Load Makefile framework. 
+include $(TEMPESTREMAPDIR)/mk/framework.make
+
+UTIL_FILES= Announce.cpp \
+            FiniteElementTools.cpp \
+			GaussLobattoQuadrature.cpp \
+			GaussQuadrature.cpp \
+			GridElements.cpp \
+			LegendrePolynomial.cpp \
+			LinearRemapFV.cpp \
+			LinearRemapSE0.cpp \
+			MeshUtilities.cpp \
+			MeshUtilitiesExact.cpp \
+			MeshUtilitiesFuzzy.cpp \
+			NetCDFUtilities.cpp \
+			OfflineMap.cpp \
+			OverlapMesh.cpp \
+			PolynomialInterp.cpp \
+			TriangularQuadrature.cpp \
+			kdtree.cpp \
+			ApplyOfflineMap.cpp \
+			GenerateConnectivityData.cpp \
+			GenerateCSMesh.cpp \
+			GenerateGLLMetaData.cpp \
+			GenerateICOMesh.cpp \
+			GenerateLambertConfConicMesh.cpp \
+			GenerateOfflineMap.cpp \
+			GenerateOverlapMesh.cpp \
+			GenerateOverlapMesh_v1.cpp \
+			GenerateRLLMesh.cpp
+
+EXEC_FILES= ApplyOfflineMapExe.cpp \
+            CalculateDiffNorms.cpp \
+            CoarsenRectilinearData.cpp \
+            GenerateConnectivityFile.cpp \
+            GenerateCSMeshExe.cpp \
+            GenerateGLLMetaDataExe.cpp \
+            GenerateICOMeshExe.cpp \
+            GenerateLambertConfConicMeshExe.cpp \
+            GenerateOfflineMapExe.cpp \
+            GenerateOverlapMeshExe.cpp \
+            GenerateOverlapMeshExe_v1.cpp \
+            GenerateRLLMeshExe.cpp \
+            GenerateTestData.cpp \
+            GenerateVolumetricMesh.cpp \
+			MeshToTxt.cpp \
+			ShpToMesh.cpp
+
+EXEC_TARGETS= $(EXEC_FILES:%.cpp=%)
+
+FILES= $(UTIL_FILES) $(EXEC_FILES)
+
+.PHONY: all clean
+
+# Build rules. 
+all: $(EXEC_TARGETS)
+
+$(EXEC_TARGETS): %: $(UTIL_FILES:%.cpp=$(BUILDDIR)/%.o) $(BUILDDIR)/%.o $(TEMPESTREMAPBASELIB)
+	-@$(CXX) $(LDFLAGS) -o $@ $(UTIL_FILES:%.cpp=$(BUILDDIR)/%.o) $(BUILDDIR)/$*.o $(TEMPESTREMAPBASELIB) $(LIBRARIES)
+	@mv $@ $(TEMPESTREMAPDIR)/bin
+
+$(TEMPESTREMAPBASELIB): %:
+	-@$(MAKE) -C $(TEMPESTREMAPDIR)/src/base -f Makefile.gmake
+
+# Clean rules.
+clean:
+	rm -rf $(DEPDIR)
+	rm -rf $(BUILDDIR)
+
+# Include dependencies.
+-include $(FILES:%.cpp=$(DEPDIR)/%.d)
+
+# DO NOT DELETE

--- a/src/TempestRemapAPI.h
+++ b/src/TempestRemapAPI.h
@@ -1,7 +1,6 @@
 #ifndef TEMPESTREMAP_API_H
 #define TEMPESTREMAP_API_H
 
-#include "TempestConfig.h"
 #include "DataMatrix3D.h"
 #include "GridElements.h"
 #include "OfflineMap.h"


### PR DESCRIPTION
The older gmake based build system has been added back. Maintenance of both autoconf and gmake system should be pursued until the gmake system is deprecated eventually. 

To use the older system, execute:
`make -f Makefile.gmake clean`
`make -f Makefile.gmake`