### PR TITLE
Remove fortran dependency during configuration

### DIFF
--- a/config/ax_blas.m4
+++ b/config/ax_blas.m4
@@ -81,7 +81,9 @@ case $with_blas in
 esac
 
 _AX_BLAS(gemm_, [ax_blas_ok=yes; ax_blas_underscore=yes],
-    [_AX_BLAS(gemm, [ax_blas_ok=yes; ax_blas_underscore=no])])
+      [_AX_BLAS(gemm, [ax_blas_ok=yes; ax_blas_underscore=no],
+      [_AX_BLAS(gemm__, [ax_blas_ok=yes; ax_blas_underscore=yes2])] )]
+      )
 
 AC_SUBST(BLAS_LIBS)
 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --with-blas=$with_blas"

--- a/config/ax_lapack.m4
+++ b/config/ax_lapack.m4
@@ -82,7 +82,15 @@ esac
 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --with-lapack=$with_lapack"
 
 # Get fortran linker name of LAPACK function to check for.
-AC_F77_FUNC(cheev)
+if (test "x$ax_blas_underscore" != "xyes"); then
+  cheev="cheev"
+else
+  if (test "x$ax_blas_underscore" != "xyes2"); then
+    cheev="cheev_"
+  else
+    cheev="cheev__"
+  fi
+fi
 
 # We cannot use LAPACK if BLAS is not found
 if test "x$ax_blas_ok" != xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -27,12 +27,9 @@ DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS CC=$CC CXX=$CXX FC=$FC"
 # TODO: Should we check for partial C++11 support also ?
 AX_CXX_COMPILE_STDCXX_0X
 
-# Checks for FORTRAN - required for BLAS/LAPACK symbol name mangling
-AC_PROG_F77([ifort gfortran g77 f77])    
-AC_F77_LIBRARY_LDFLAGS
-LIBS="$LIBS $FCLIBS -lm"
-
-# Checks for libraries.
+# Checks for some standard libraries.
+AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
+AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
 
 # Checks for BLAS/LAPACK libraries:
 AX_BLAS([], [AC_MSG_ERROR([BLAS library not found])])


### PR DESCRIPTION
Remove requirements for a Fortran compiler, which was previously needed in order to decipher the symbol name mangling in BLAS/LAPACK. 

Now we try 3 different variations for BLAS:
1. Symbol with no underscores (GNU with -fno-underscoring)
2. Symbol with one underscore (GNU/Intel/PGI default setting)
3. Symbol with two underscores (GNU with -ff2c option)

This setting is remembered and reused for LAPACK symbol checks. Verified locally on OSX and Ubuntu workstation. Checks on LCF should pass as well.