### PR TITLE
Add verbosity flag for ConstructEdgeMap

### DIFF
--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -75,7 +75,7 @@ void Mesh::Clear() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void Mesh::ConstructEdgeMap() {
+void Mesh::ConstructEdgeMap(bool verbose) {
 
 	// Construct the edge map
 	edgemap.clear();
@@ -99,7 +99,7 @@ void Mesh::ConstructEdgeMap() {
 		}
 	}
 
-	Announce("Mesh size: Edges [%i]", edgemap.size());
+	if (verbose) Announce("Mesh size: Edges [%i]", edgemap.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -721,7 +721,7 @@ public:
 	///	<summary>
 	///		Construct the EdgeMap from the NodeVector and FaceVector.
 	///	</summary>
-	void ConstructEdgeMap();
+	void ConstructEdgeMap(bool verbose=true);
 
 	///	<summary>
 	///		Construct the ReverseNodeArray from the NodeVector and FaceVector.


### PR DESCRIPTION
Very simple change to make sure we don't spew out a lot of output in parallel within the MBTR workflow.