### PR TITLE
use free after using malloc

### DIFF
--- a/src/DataArray1D.h
+++ b/src/DataArray1D.h
@@ -155,7 +155,7 @@ public:
 	///	</summary>
 	virtual void Detach() {
 		if ((m_fOwnsData) && (m_data != NULL)) {
-			delete[] m_data;
+		        free(m_data);
 		}
 		m_fOwnsData = true;
 		m_data = NULL;

--- a/src/DataArray2D.h
+++ b/src/DataArray2D.h
@@ -180,7 +180,7 @@ public:
 	///	</summary>
 	virtual void Detach() {
 		if ((m_fOwnsData) && (m_data1D != NULL)) {
-			delete[] m_data1D;
+		        free(m_data1D);
 		}
 		m_fOwnsData = true;
 		m_data1D = NULL;

--- a/src/DataArray3D.h
+++ b/src/DataArray3D.h
@@ -191,7 +191,7 @@ public:
 	///	</summary>
 	virtual void Detach() {
 		if ((m_fOwnsData) && (m_data1D != NULL)) {
-			delete[] m_data1D;
+			free(m_data1D);
 		}
 		m_fOwnsData = true;
 		m_data1D = NULL;


### PR DESCRIPTION
arrays were allocated in DataArray1D, 2D, 3D, using malloc but freed using delete []
This probably wouldn't cause any errors, but it causes problems with memory tracking tools