### PR TITLE
need to set _FillValue before writing any data

### DIFF
--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -924,15 +924,19 @@ void Mesh::WriteScrip(
 				}
 			}
 		}
+		varCenterLat->add_att("_FillValue", 9.96920996838687e+36 );
+                varCenterLon->add_att("_FillValue", 9.96920996838687e+36 );
+		varCornerLat->add_att("_FillValue", 9.96920996838687e+36 );
+		varCornerLon->add_att("_FillValue", 9.96920996838687e+36 );
+
 		varCenterLat->set_cur((long)0);
 		varCenterLat->put(centerLat, nElementCount);
 		varCenterLat->add_att("units", "degrees");
-		varCenterLat->add_att("_FillValue", 9.96920996838687e+36 );
 
 		varCenterLon->set_cur((long)0);
 		varCenterLon->put(centerLon, nElementCount);
 		varCenterLon->add_att("units", "degrees");
-		varCenterLon->add_att("_FillValue", 9.96920996838687e+36 );
+
 
 		for (int i=0; i<nElementCount; i++) {
 			varCornerLat->set_cur(i,0);
@@ -942,8 +946,6 @@ void Mesh::WriteScrip(
 		}
 		varCornerLat->add_att("units", "degrees");
 		varCornerLon->add_att("units", "degrees");
-		varCornerLat->add_att("_FillValue", 9.96920996838687e+36 );
-		varCornerLon->add_att("_FillValue", 9.96920996838687e+36 );
 	}
 	//---------------------------------------------------------------------------
 	// Grid mask
@@ -952,13 +954,14 @@ void Mesh::WriteScrip(
 		if (varMask == NULL) {
 			_EXCEPTIONT("Error creating variable \"grid_imask\"");
 		}
+		varMask->add_att("_FillValue", 9.96920996838687e+36 );
 		DataArray1D<double> mask(nElementCount);
 		for (int i = 0; i < nElementCount; i++) {
 			mask[i] = static_cast<double>( 1 );
 		}
 		varMask->set_cur((long)0);
 		varMask->put(mask, nElementCount);
-		varMask->add_att("_FillValue", 9.96920996838687e+36 );
+
 	}
 	//---------------------------------------------------------------------------
 	// Grid dims


### PR DESCRIPTION
with netcdf 4.6.3 (Darwin), and on the E3SM Compy machine, I'm getting errors converting to SCRIP format about setting _FillValue after data has been written to the array.  The ConvertExodusToScrip program aborts on errors, resulting in an incomplete scrip file.

with this patch, the code runs and generates a complete scrip file.  

Example showing error:

```
+ NE=4
+ atmgridnp4=TEMPEST_NE4.g
+ atmgrid=TEMPEST_NE4pg2.g
+ atmgrid_scrip=TEMPEST_NE4pg2.scrip.nc
+ /compyfs/software/tempestremap/intel/19.0.3/bin/GenerateCSMesh --alt --res 4 --out_format Netcdf4 --file TEMPEST_NE4.g
Parameters:
  --res <integer> [4] 
  --alt <bool> [true] 
  --file <string> ["TEMPEST_NE4.g"] 
  --out_format <string> ["Netcdf4"] 
=========================================================
..Generating mesh with resolution [4]
..Writing mesh to file [TEMPEST_NE4.g] 
Nodes per element
..Block 1 (4 nodes): 96
..Mesh generator exited successfully
=========================================================
+ /compyfs/software/tempestremap/intel/19.0.3/bin/GenerateVolumetricMesh --in TEMPEST_NE4.g --out TEMPEST_NE4pg2.g --np 2 --uniform
Parameters:
  --in <string> ["TEMPEST_NE4.g"] 
  --out <string> ["TEMPEST_NE4pg2.g"] 
  --np <integer> [2] 
  --uniform <bool> [true] 
------------------------------------------------------------

..Loading input mesh
Mesh size: Nodes [98] Elements [96]
..Computing sub-volume boundaries
..Generating sub-volumes
..Writing mesh
Nodes per element
..Block 1 (4 nodes): 384
..Mesh generator exited successfully
=========================================================
+ /compyfs/software/tempestremap/intel/19.0.3/bin/ConvertExodusToSCRIP --in TEMPEST_NE4pg2.g --out TEMPEST_NE4pg2.scrip.nc
Parameters:
  --in <string> ["TEMPEST_NE4pg2.g"] 
  --out <string> ["TEMPEST_NE4pg2.scrip.nc"] 
  --out_format <string> ["netcdf4"] 
------------------------------------------------------------

..Loading input mesh
Mesh size: Nodes [386] Elements [384]
..Writing mesh
Nodes per element
..Block 1 (4 nodes): 384
NetCDF: Attempt to define fill value when data already exists.

```