### PR TITLE
Propagate verbose flag for coincident nodes check

### DIFF
--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -258,7 +258,7 @@ void Mesh::ExchangeFirstAndSecondMesh() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void Mesh::RemoveCoincidentNodes() {
+void Mesh::RemoveCoincidentNodes(bool verbose) {
 
 	// Put nodes into a map, tagging uniques
 	std::map<Node, int> mapNodes;

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -75,7 +75,9 @@ void Mesh::Clear() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void Mesh::ConstructEdgeMap(bool verbose) {
+void Mesh::ConstructEdgeMap(
+  bool fVerbose
+) {
 
 	// Construct the edge map
 	edgemap.clear();
@@ -99,7 +101,7 @@ void Mesh::ConstructEdgeMap(bool verbose) {
 		}
 	}
 
-	if (verbose) Announce("Mesh size: Edges [%i]", edgemap.size());
+	if (fVerbose) Announce("Mesh size: Edges [%i]", edgemap.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -258,7 +260,9 @@ void Mesh::ExchangeFirstAndSecondMesh() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void Mesh::RemoveCoincidentNodes(bool verbose) {
+void Mesh::RemoveCoincidentNodes(
+  bool fVerbose
+) {
 
 	// Put nodes into a map, tagging uniques
 	std::map<Node, int> mapNodes;
@@ -285,7 +289,7 @@ void Mesh::RemoveCoincidentNodes(bool verbose) {
 		return;
 	}
 
-	if(verbose) {
+	if(fVerbose) {
 		Announce("%i duplicate nodes detected", nodes.size() - vecUniques.size());
 	}
 

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -285,7 +285,9 @@ void Mesh::RemoveCoincidentNodes() {
 		return;
 	}
 
-	Announce("%i duplicate nodes detected", nodes.size() - vecUniques.size());
+	if(verbose) {
+		Announce("%i duplicate nodes detected", nodes.size() - vecUniques.size());
+	}
 
 	// Remove duplicates
 	NodeVector nodesOld = nodes;

--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -722,7 +722,9 @@ public:
 	///	<summary>
 	///		Construct the EdgeMap from the NodeVector and FaceVector.
 	///	</summary>
-	void ConstructEdgeMap(bool verbose=true);
+	void ConstructEdgeMap(
+	  bool fVerbose = true
+	);
 
 	///	<summary>
 	///		Construct the ReverseNodeArray from the NodeVector and FaceVector.
@@ -751,7 +753,9 @@ public:
 	///	<summary>
 	///		Remove coincident nodes from the Mesh and adjust indices in faces.
 	///	</summary>
-	void RemoveCoincidentNodes(bool verbose=true);
+	void RemoveCoincidentNodes(
+	  bool fVerbose = true
+	);
 
 	///	<summary>
 	///		Write the mesh to a NetCDF file in Exodus format.

--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -751,7 +751,7 @@ public:
 	///	<summary>
 	///		Remove coincident nodes from the Mesh and adjust indices in faces.
 	///	</summary>
-	void RemoveCoincidentNodes();
+	void RemoveCoincidentNodes(bool verbose=true);
 
 	///	<summary>
 	///		Write the mesh to a NetCDF file in Exodus format.


### PR DESCRIPTION
Make output less verbose when needed. Default is verbose=false in TempestRemap runs