### PR TITLE
Make some private routines to protected scope

### DIFF
--- a/src/OfflineMap.h
+++ b/src/OfflineMap.h
@@ -94,7 +94,7 @@ public:
         const std::vector<int>& p_tgtDimSizes
     );
 
-private:
+protected:
 	///	<summary>
 	///		Initialize the coordinate arrays for a finite-volume mesh.
 	///	</summary>


### PR DESCRIPTION
Make InitializeCoordinatesFromMeshFV and InitializeCoordinatesFromMeshFE routines protected so that derived classes can invoke them and compute center/vertex coordinates as needed.

This is used from the OnlineMap computation routines in MOAB when writing the file in h5m format.