### PR TITLE
OfflineMap::InitializeCoordinatesFromMeshFV API update

### DIFF
--- a/src/OfflineMap.cpp
+++ b/src/OfflineMap.cpp
@@ -337,22 +337,24 @@ void OfflineMap::InitializeCoordinatesFromMeshFV(
 	DataArray1D<double> & dCenterLat,
 	DataArray2D<double> & dVertexLon,
 	DataArray2D<double> & dVertexLat,
-	bool fLatLon
+	bool fLatLon,
+	int nNodesPerFace
 ) {
-	int nFaces = mesh.faces.size();
-
-	// Count maximum number of Nodes per Face
-	int nNodesPerFace = 0;
-	for (int i = 0; i < nFaces; i++) {
-		if (mesh.faces[i].edges.size() > nNodesPerFace) {
-			nNodesPerFace = mesh.faces[i].edges.size();
-		}
-	}
-
 	// Check if already initialized
 	if (dCenterLon.GetRows() != 0) {
 		return;
 	}
+
+	int nFaces = mesh.faces.size();
+
+	// Count maximum number of Nodes per Face
+	if (nNodesPerFace == 0) {
+    for (int i = 0; i < nFaces; i++) {
+      if (mesh.faces[i].edges.size() > nNodesPerFace) {
+        nNodesPerFace = mesh.faces[i].edges.size();
+      }
+    }
+  }
 
 	dVertexLon.Allocate(nFaces, nNodesPerFace);
 	dVertexLat.Allocate(nFaces, nNodesPerFace);

--- a/src/OfflineMap.h
+++ b/src/OfflineMap.h
@@ -104,7 +104,8 @@ protected:
 		DataArray1D<double> & dCenterLat,
 		DataArray2D<double> & dVertexLon,
 		DataArray2D<double> & dVertexLat,
-		bool fLatLon
+		bool fLatLon,
+		int nNodesPerFace = 0
 	);
 
 	///	<summary>


### PR DESCRIPTION
Take in the maximum number of nodes per element in the current mesh as an input if the user already knows this information. This is important when invoked in parallel (from MOAB) since at high-resolution, some processes could have say max of 5 `nve` and other processes could have 7 `nve` for a mixed MPAS grid. This leads to problems when writing out the CoordVertexLon/Lat variables as the offset is no longer constant (and map file is different in serial and parallel runs).

The updated API on protected method makes this recomputation simpler when doing I/O.