### PR TITLE
Bugfix: Higher order FV-FV BuildIntegrationArray

### DIFF
--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -364,9 +364,9 @@ void BuildIntegrationArray(
 
 	for (int i = ixOverlapBegin; i < ixOverlapEnd; i++) {
 
-		const Face & faceOverlap = meshOverlap.faces[ixOverlapBegin + i];
+		const Face & faceOverlap = meshOverlap.faces[i];
 
-		nTotalOverlapTriangles += faceOverlap.edges.size() - 2; 
+		nTotalOverlapTriangles += faceOverlap.edges.size() - 2;
 	}
 
 	// Build integration array

--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -360,15 +360,6 @@ void BuildIntegrationArray(
 	// Number of overlapping faces and triangles
 	int nOverlapFaces = ixOverlapEnd - ixOverlapBegin;
 
-	int nTotalOverlapTriangles = 0;
-
-	for (int i = ixOverlapBegin; i < ixOverlapEnd; i++) {
-
-		const Face & faceOverlap = meshOverlap.faces[i];
-
-		nTotalOverlapTriangles += faceOverlap.edges.size() - 2;
-	}
-
 	// Build integration array
 	dIntArray.Allocate(nCoefficients, nOverlapFaces);
 


### PR DESCRIPTION
Fix a potentially serious memory corruption bug for higher order FV-FV. 

The numerics for map generation does not get affected, but memory overflow on read may happen depending on the overlap grid.