### PR TITLE
Modifications to the NetCDF-C++ interfaces to allow NcFile extensions

### DIFF
--- a/src/netcdf.cpp
+++ b/src/netcdf.cpp
@@ -21,7 +21,7 @@
 
 static const int ncGlobal = NC_GLOBAL; // psuedo-variable for global attributes
 
-static const int ncBad = -1;	// failure return for netCDF C interface 
+static const int ncBad = -1;	// failure return for netCDF C interface
 
 NcFile::~NcFile( void )
 {
@@ -298,7 +298,7 @@ NcBool NcFile::sync( void )
 NcBool NcFile::close( void )
 {
     int i;
-    
+
     if (the_id == ncBad)
       return 0;
     for (i = 0; i < num_dims(); i++)
@@ -355,7 +355,16 @@ int NcFile::id( void ) const
     return the_id;
 }
 
-NcFile::NcFile( const char* path, FileMode fmode, 
+NcFile::NcFile()
+{
+    the_id = -1;
+    the_fill_mode = Fill;
+    dimensions = 0;
+    variables = 0;
+    globalv = 0;
+}
+
+NcFile::NcFile( const char* path, FileMode fmode,
 		size_t* bufrsizeptr, size_t initialsize, FileFormat fformat  )
 {
     NcError err(NcError::silent_nonfatal); // constructor must not fail
@@ -363,7 +372,7 @@ NcFile::NcFile( const char* path, FileMode fmode,
     int mode = NC_NOWRITE;
     the_fill_mode = Fill;
     int status;
-    
+
     // If the user wants a 64-bit offset format, set that flag.
     if (fformat == Offset64Bits)
        mode |= NC_64BIT_OFFSET;
@@ -480,8 +489,8 @@ int NcDim::id( void ) const
     return the_id;
 }
 
-NcBool NcDim::sync(void) 
-{    
+NcBool NcDim::sync(void)
+{
     char nam[NC_MAX_NAME];
     if (the_name) {
 	delete [] the_name;
@@ -489,7 +498,7 @@ NcBool NcDim::sync(void)
     if (the_file && NcError::set_err(
 				     nc_inq_dimname(the_file->id(), the_id, nam)
 				     ) == NC_NOERR) {
-	the_name = new char[strlen(nam) + 1]; 
+	the_name = new char[strlen(nam) + 1];
 	strcpy(the_name, nam);
 	return TRUE;
     }
@@ -507,7 +516,7 @@ NcDim::NcDim(NcFile* nc, int id)
   if (the_file && NcError::set_err(
             nc_inq_dimname(the_file->id(), the_id, nam)
             ) == NC_NOERR) {
-    the_name = new char[strlen(nam) + 1]; 
+    the_name = new char[strlen(nam) + 1];
     strcpy(the_name, nam);
   } else {
     the_name = 0;
@@ -708,37 +717,37 @@ NcValues* NcVar::values( void ) const
     switch (type()) {
     case ncFloat:
 	status = NcError::set_err(
-				  nc_get_vara_float(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_float(the_file->id(), the_id, crnr, edgs,
 				   (float *)valp->base())
 				  );
 	break;
     case ncDouble:
 	status = NcError::set_err(
-				  nc_get_vara_double(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_double(the_file->id(), the_id, crnr, edgs,
 				    (double *)valp->base())
 				  );
 	break;
     case ncInt:
 	status = NcError::set_err(
-				  nc_get_vara_int(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_int(the_file->id(), the_id, crnr, edgs,
 				 (int *)valp->base())
 				  );
 	break;
     case ncShort:
 	status = NcError::set_err(
-				  nc_get_vara_short(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_short(the_file->id(), the_id, crnr, edgs,
 				   (short *)valp->base())
 				  );
 	break;
     case ncByte:
 	status = NcError::set_err(
-				  nc_get_vara_schar(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_schar(the_file->id(), the_id, crnr, edgs,
 				   (signed char *)valp->base())
 				  );
 	break;
     case ncChar:
 	status = NcError::set_err(
-				  nc_get_vara_text(the_file->id(), the_id, crnr, edgs, 
+				  nc_get_vara_text(the_file->id(), the_id, crnr, edgs,
 				   (char *)valp->base())
 				  );
 	break;
@@ -767,10 +776,10 @@ void NcVar::set_rec(NcDim *rdim, long slice)
   int i = dim_to_index(rdim);
   // we should fail and gripe about it here....
   if (slice >= get_dim(i)->size() && ! get_dim(i)->is_unlimited())
-	  return;  
+	  return;
   cur_rec[i] = slice;
   return;
-} 
+}
 
 void NcVar::set_rec(long rec)
 {
@@ -778,7 +787,7 @@ void NcVar::set_rec(long rec)
   // just assume [0] is it.....
   set_rec(get_dim(0),rec);
   return;
-} 
+}
 
 NcValues* NcVar::get_rec(void)
 {
@@ -821,37 +830,37 @@ NcValues* NcVar::get_rec(NcDim* rdim, long slice)
     switch (type()) {
     case ncFloat:
 	status = NcError::set_err(
-				  nc_get_vara_float(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_float(the_file->id(), the_id, start, edge,
 				   (float *)valp->base())
 				  );
 	break;
     case ncDouble:
 	status = NcError::set_err(
-				  nc_get_vara_double(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_double(the_file->id(), the_id, start, edge,
 				    (double *)valp->base())
 				  );
 	break;
     case ncInt:
 	status = NcError::set_err(
-				  nc_get_vara_int(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_int(the_file->id(), the_id, start, edge,
 				 (int *)valp->base())
 				  );
 	break;
     case ncShort:
 	status = NcError::set_err(
-				  nc_get_vara_short(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_short(the_file->id(), the_id, start, edge,
 				   (short *)valp->base())
 				  );
 	break;
     case ncByte:
 	status = NcError::set_err(
-				  nc_get_vara_schar(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_schar(the_file->id(), the_id, start, edge,
 				   (signed char *)valp->base())
 				  );
 	break;
     case ncChar:
 	status = NcError::set_err(
-				  nc_get_vara_text(the_file->id(), the_id, start, edge, 
+				  nc_get_vara_text(the_file->id(), the_id, start, edge,
 				   (char *)valp->base())
 				  );
 	break;
@@ -868,7 +877,7 @@ NcValues* NcVar::get_rec(NcDim* rdim, long slice)
 	return 0;
     }
     return valp;
-} 
+}
 
 
 #define NcVar_put_rec(TYPE)                                                   \
@@ -922,7 +931,7 @@ long NcVar::rec_size(void) {
 }
 
 long NcVar::rec_size(NcDim *rdim) {
-    int idx = dim_to_index(rdim); 
+    int idx = dim_to_index(rdim);
     long size = 1;
     long* edge = edges();
     for( int i = 0 ; i<num_dims() ; i++) {
@@ -971,9 +980,9 @@ NcVar_get_index(nclong)
 NcVar_get_index(long)
 NcVar_get_index(float)
 NcVar_get_index(double)
-    
+
 // Macros below work for short, nclong, long, float, and double, but for ncbyte
-// and char, we must use corresponding schar, uchar, or text C functions, so in 
+// and char, we must use corresponding schar, uchar, or text C functions, so in
 // these cases macros are expanded manually.
 #define NcVar_put_array(TYPE)						      \
 NcBool NcVar::put( const TYPE* vals,					      \
@@ -1438,7 +1447,7 @@ NcBool NcVar::sync(void)
 	delete [] cur_rec;
     }
     char nam[NC_MAX_NAME];
-    if (the_file 
+    if (the_file
 	&& NcError::set_err(
 			    nc_inq_varname(the_file->id(), the_id, nam)
 			    ) == NC_NOERR) {
@@ -1448,7 +1457,7 @@ NcBool NcVar::sync(void)
 	the_name = 0;
 	return FALSE;
     }
-    init_cur(); 
+    init_cur();
     return TRUE;
 }
 
@@ -1457,7 +1466,7 @@ NcVar::NcVar(NcFile* nc, int id)
    : NcTypedComponent(nc), the_id(id)
 {
     char nam[NC_MAX_NAME];
-    if (the_file 
+    if (the_file
 	&& NcError::set_err(
 			    nc_inq_varname(the_file->id(), the_id, nam)
 			    ) == NC_NOERR) {
@@ -1501,7 +1510,7 @@ void NcVar::init_cur( void )
 {
     the_cur = new long[NC_MAX_DIMS]; // *** don't know num_dims() yet?
     cur_rec = new long[NC_MAX_DIMS]; // *** don't know num_dims() yet?
-    for(int i = 0; i < NC_MAX_DIMS; i++) { 
+    for(int i = 0; i < NC_MAX_DIMS; i++) {
 	the_cur[i] = 0; cur_rec[i] = 0; }
 }
 

--- a/src/netcdf.cpp
+++ b/src/netcdf.cpp
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <iostream>
 
+#include "Exception.h"
+
 #ifndef TRUE
 #define TRUE 1
 #define FALSE 0
@@ -498,8 +500,8 @@ NcBool NcDim::sync(void)
 NcDim::NcDim(NcFile* nc, int id)
 	: the_file(nc), the_id(id)
 {
-  assert(nc != NULL);
-  assert(nc->is_valid());
+  _ASSERT(nc != NULL);
+  _ASSERT(nc->is_valid());
 
   char nam[NC_MAX_NAME];
   if (the_file && NcError::set_err(
@@ -560,8 +562,8 @@ char* NcTypedComponent::as_string( long n ) const
 NcTypedComponent::NcTypedComponent ( NcFile* nc )
 	: the_file(nc)
 {
-  assert(nc != NULL);
-  assert(nc->is_valid());
+  _ASSERT(nc != NULL);
+  _ASSERT(nc->is_valid());
 }
 
 NcValues* NcTypedComponent::get_space( long numVals ) const

--- a/src/netcdf.cpp
+++ b/src/netcdf.cpp
@@ -498,15 +498,18 @@ NcBool NcDim::sync(void)
 NcDim::NcDim(NcFile* nc, int id)
 	: the_file(nc), the_id(id)
 {
-    char nam[NC_MAX_NAME];
-    if (the_file && NcError::set_err(
-				     nc_inq_dimname(the_file->id(), the_id, nam)
-				     ) == NC_NOERR) {
-	the_name = new char[strlen(nam) + 1]; 
-	strcpy(the_name, nam);
-    } else {
-	the_name = 0;
-    }
+  assert(nc != NULL);
+  assert(nc->is_valid());
+
+  char nam[NC_MAX_NAME];
+  if (the_file && NcError::set_err(
+            nc_inq_dimname(the_file->id(), the_id, nam)
+            ) == NC_NOERR) {
+    the_name = new char[strlen(nam) + 1]; 
+    strcpy(the_name, nam);
+  } else {
+    the_name = 0;
+  }
 }
 
 NcDim::NcDim(NcFile* nc, NcToken name, long sz)
@@ -556,7 +559,10 @@ char* NcTypedComponent::as_string( long n ) const
 
 NcTypedComponent::NcTypedComponent ( NcFile* nc )
 	: the_file(nc)
-{}
+{
+  assert(nc != NULL);
+  assert(nc->is_valid());
+}
 
 NcValues* NcTypedComponent::get_space( long numVals ) const
 {

--- a/src/netcdf.cpp
+++ b/src/netcdf.cpp
@@ -1465,7 +1465,7 @@ NcBool NcVar::sync(void)
 NcVar::NcVar(NcFile* nc, int id)
    : NcTypedComponent(nc), the_id(id)
 {
-    char nam[NC_MAX_NAME];
+    char nam[NC_MAX_NAME]={0};
     if (the_file
 	&& NcError::set_err(
 			    nc_inq_varname(the_file->id(), the_id, nam)

--- a/src/netcdfcpp.h
+++ b/src/netcdfcpp.h
@@ -155,6 +155,7 @@ class NcDim
     int the_id;
     char *the_name;
 
+  public:
     NcDim(NcFile*, int num);	// existing dimension
     NcDim(NcFile*, NcToken name, long sz); // defines a new dim
     virtual ~NcDim( void );
@@ -388,9 +389,12 @@ class NcVar : public NcTypedComponent
     char* the_name;
     long* cur_rec;
 
+  public:
+    NcVar(NcFile*, int);
+
+  protected:
     // private constructors because only an NcFile creates these
     NcVar( void );
-    NcVar(NcFile*, int);
 
     int attnum( NcToken attname ) const;
     NcToken attname( int attnum ) const;
@@ -422,8 +426,10 @@ class NcAtt : public NcTypedComponent
   private:
     const NcVar* the_variable;
     char* the_name;
-    // protected constructors because only NcVars and NcFiles create
-    // attributes
+
+  public:
+    // public constructors but only NcVars and NcFiles create
+    // attributes with valid NcFile objects
     NcAtt( NcFile*, const NcVar*, NcToken);
     NcAtt( NcFile*, NcToken); // global attribute
     

--- a/src/netcdfcpp.h
+++ b/src/netcdfcpp.h
@@ -64,7 +64,7 @@ class NcFile
     NcVar* get_var( int ) const;           // n-th variable
     NcAtt* get_att( int ) const;           // n-th global attribute
     NcDim* rec_dim( void ) const;          // unlimited dimension, if any
-    
+
     // Add new dimensions, variables, global attributes.
     // These put the file in "define" mode, so could be expensive.
     virtual NcDim* add_dim( NcToken dimname, long dimsize );
@@ -108,13 +108,16 @@ class NcFile
     NcBool sync( void );                   // synchronize to disk
     NcBool close( void );                  // to close earlier than dtr
     NcBool abort( void );                  // back out of bad defines
-    
+
     // Needed by other Nc classes, but users will not need them
     NcBool define_mode( void ); // leaves in define mode, if possible
     NcBool data_mode( void );   // leaves in data mode, if possible
     int id( void ) const;       // id used by C interface
 
   protected:
+    /* Let the derived class handle initializing all necessary data */
+    NcFile();
+
     int the_id;
     int in_define_mode;
     FillMode the_fill_mode;
@@ -159,7 +162,7 @@ class NcDim
     NcDim(NcFile*, int num);	// existing dimension
     NcDim(NcFile*, NcToken name, long sz); // defines a new dim
     virtual ~NcDim( void );
-    
+
     // to construct dimensions, since constructor is private
     friend class NcFile;
 };
@@ -179,7 +182,7 @@ class NcTypedComponent
     virtual NcToken name( void ) const = 0;
     virtual NcType type( void ) const = 0;
     virtual NcBool is_valid( void ) const = 0;
-    virtual long num_vals( void ) const = 0; 
+    virtual long num_vals( void ) const = 0;
     virtual NcBool rename( NcToken newname ) = 0;
     virtual NcValues* values( void ) const = 0; // block of all values
 
@@ -225,7 +228,7 @@ class NcVar : public NcTypedComponent
     NcAtt* get_att( int ) const;        // n-th attribute
     long num_vals( void ) const;        // product of dimension sizes
     NcValues* values( void ) const;     // all values
-    
+
     // Put scalar or 1, ..., 5 dimensional arrays by providing enough
     // arguments.  Arguments are edge lengths, and their number must not
     // exceed variable's dimensionality.  Start corner is [0,0,..., 0] by
@@ -273,7 +276,7 @@ class NcVar : public NcTypedComponent
     NcBool get( float* vals, long c0=0, long c1=0,
                 long c2=0, long c3=0, long c4=0 ) const;
     NcBool get( double* vals, long c0=0, long c1=0,
-                long c2=0, long c3=0, long c4=0 ) const; 
+                long c2=0, long c3=0, long c4=0 ) const;
 
     // Get n-dimensional arrays, starting at [0, 0, ..., 0] by default,
     // may be reset with set_cur().
@@ -381,7 +384,7 @@ class NcVar : public NcTypedComponent
 
     int id( void ) const;               // rarely needed, C interface id
     NcBool sync( void );
-    
+
   private:
     int dim_to_index(NcDim* rdim);
     int the_id;
@@ -413,12 +416,12 @@ class NcVar : public NcTypedComponent
  */
 class NcAtt : public NcTypedComponent
 {
-  public:          
+  public:
     virtual ~NcAtt( void );
     NcToken name( void ) const;
     NcType type( void ) const;
     NcBool is_valid( void ) const;
-    long num_vals( void ) const; 
+    long num_vals( void ) const;
     NcValues* values( void ) const;
     NcBool rename( NcToken newname );
     NcBool remove( void );
@@ -432,7 +435,7 @@ class NcAtt : public NcTypedComponent
     // attributes with valid NcFile objects
     NcAtt( NcFile*, const NcVar*, NcToken);
     NcAtt( NcFile*, NcToken); // global attribute
-    
+
     // To make attributes, since constructor is private
   friend class NcFile;
   friend NcAtt* NcVar::get_att( NcToken ) const;
@@ -452,7 +455,7 @@ class NcError {
         silent_nonfatal = 0,
         silent_fatal = 1,
         verbose_nonfatal = 2,
-        verbose_fatal = 3   
+        verbose_fatal = 3
       };
 
     // constructor saves previous error state, sets new state


### PR DESCRIPTION
Expose public constructors in NetCDF C++ classes for NcVar/NcDim etc so that parallel extensions using derived classes in downstream packages (MOAB) can be implemented easily with minimal interface and code additions.

Note that to obtain parallelism with NetCDF v4+, we need NetCDF to be compiled with HDF5 and MPI.