### PR TITLE
Modifications to the NetCDF-C++ interfaces to allow NcFile extensions

### DIFF
--- a/src/netcdf.cpp
+++ b/src/netcdf.cpp
@@ -23,6 +23,15 @@ static const int ncGlobal = NC_GLOBAL;
 // failure return for netCDF C interface
 static const int ncBad = -1;	 
 
+NcFile::NcFile()
+{
+	the_id = -1;
+	the_fill_mode = Fill;
+	dimensions = 0;
+	variables = 0;
+	globalv = 0;
+}
+
 NcFile::~NcFile( void ) {
 	(void) close();
 }

--- a/src/netcdfcpp.h
+++ b/src/netcdfcpp.h
@@ -122,6 +122,9 @@ public:
 	int id( void ) const;                  // id used by C interface
 
   protected:
+  /* Let the derived class handle initializing all necessary data */
+  NcFile();
+
 	int the_id;
 	int in_define_mode;
 	FillMode the_fill_mode;
@@ -158,6 +161,7 @@ private:
 	int the_id;
 	char *the_name;
 
+public:
 	NcDim(NcFile*, int num);               // existing dimension
 	NcDim(NcFile*, NcToken name, long sz); // defines a new dim
 	virtual ~NcDim( void );
@@ -412,20 +416,21 @@ public:
 	int id( void ) const;   // rarely needed, C interface id
 	NcBool sync( void );
 
-private:
+protected:
 	int dim_to_index(NcDim* rdim);
 	int the_id;
 	long* the_cur;
 	char* the_name;
 	long* cur_rec;
 
-	// private constructors because only an NcFile creates these
-	NcVar( void );
-	NcVar(NcFile*, int);
-
 	int attnum( NcToken attname ) const;
 	NcToken attname( int attnum ) const;
 	void init_cur( void );
+
+public:
+	// Only an NcFile or derivatives create these with a valid handle
+	NcVar( void );
+	NcVar(NcFile*, int);
 
 	// to make variables, since constructor is private
 	friend class NcFile;
@@ -451,8 +456,8 @@ private:
 	const NcVar* the_variable;
 	char* the_name;
 
-	// protected constructors because only NcVars and NcFiles create
-	// attributes
+public:
+	// Only NcVars and NcFiles with a valid handle create attributes
 	NcAtt( NcFile*, const NcVar*, NcToken);
 	NcAtt( NcFile*, NcToken); // global attribute
 	


### PR DESCRIPTION
Modifications to the NetCDF-C++ interfaces to allow NcFile extensions and more specifically, derived classes for parallel read/write from MOAB. This change-set exposes public constructors in NetCDF C++ classes for NcVar/NcDim etc so that parallel extensions using derived classes in downstream packages (MOAB) can be implemented easily with minimal interface and code additions.

Note that to obtain parallelism with NetCDF v4+, we need NetCDF to be compiled with HDF5 and MPI.