### PR TITLE
Remove usage of dC, which is too large 

### DIFF
--- a/src/GenerateOfflineMap.cpp
+++ b/src/GenerateOfflineMap.cpp
@@ -142,7 +142,7 @@ int GenerateOfflineMapWithMeshes(
 	std::string strNColName, bool fOutputDouble,
 	std::string strOutputFormat,
 	std::string strPreserveVariables, bool fPreserveAll, double dFillValueOverride,
-	bool fSourceConcave, bool fTargetConcave, bool useSparseConstraints
+	bool fSourceConcave, bool fTargetConcave, bool fSparseConstraints
 ) {
 	NcError error(NcError::silent_nonfatal);
 
@@ -553,7 +553,7 @@ try {
             nMonotoneType,
             fContinuousIn,
             fNoConservation,
-            useSparseConstraints,
+            fSparseConstraints,
             mapRemap
         );
 
@@ -809,7 +809,7 @@ int GenerateOfflineMap(
 	bool fPreserveAll,
 	double dFillValueOverride,
 	bool fSourceConcave, bool fTargetConcave,
-	bool useSparseConstraints)
+	bool fSparseConstraints)
 {
 	NcError error(NcError::silent_nonfatal);
 
@@ -870,7 +870,7 @@ try {
                                             strInputData, strOutputData,
                                             strNColName, fOutputDouble, strOutputFormat,
                                             strPreserveVariables, fPreserveAll, dFillValueOverride,
-                                            fSourceConcave, fTargetConcave, useSparseConstraints );
+                                            fSourceConcave, fTargetConcave, fSparseConstraints );
 
     return err;
 

--- a/src/GenerateOfflineMap.cpp
+++ b/src/GenerateOfflineMap.cpp
@@ -142,7 +142,7 @@ int GenerateOfflineMapWithMeshes(
 	std::string strNColName, bool fOutputDouble,
 	std::string strOutputFormat,
 	std::string strPreserveVariables, bool fPreserveAll, double dFillValueOverride,
-	bool fSourceConcave, bool fTargetConcave
+	bool fSourceConcave, bool fTargetConcave, bool useSparseConstraints
 ) {
 	NcError error(NcError::silent_nonfatal);
 
@@ -553,6 +553,7 @@ try {
             nMonotoneType,
             fContinuousIn,
             fNoConservation,
+            useSparseConstraints,
             mapRemap
         );
 
@@ -807,7 +808,8 @@ int GenerateOfflineMap(
 	std::string strPreserveVariables,
 	bool fPreserveAll,
 	double dFillValueOverride,
-	bool fSourceConcave, bool fTargetConcave )
+	bool fSourceConcave, bool fTargetConcave,
+	bool useSparseConstraints)
 {
 	NcError error(NcError::silent_nonfatal);
 
@@ -868,7 +870,7 @@ try {
                                             strInputData, strOutputData,
                                             strNColName, fOutputDouble, strOutputFormat,
                                             strPreserveVariables, fPreserveAll, dFillValueOverride,
-                                            fSourceConcave, fTargetConcave );
+                                            fSourceConcave, fTargetConcave, useSparseConstraints );
 
     return err;
 
@@ -971,6 +973,8 @@ int main(int argc, char** argv) {
 	// Output mesh contains concave elements
 	bool fTargetConcave;
 
+	bool fSparseConstraints;
+
 	// Parse the command line
 	BeginCommandLine()
 		CommandLineString(strInputMesh, "in_mesh", "");
@@ -1003,6 +1007,7 @@ int main(int argc, char** argv) {
 		CommandLineDouble(dFillValueOverride, "fillvalue", 0.0);
 		CommandLineBool(fSourceConcave, "in_concave");
 		CommandLineBool(fTargetConcave, "out_concave");
+		CommandLineBool(fSparseConstraints, "sparse_constraints");
 
 		ParseCommandLine(argc, argv);
 	EndCommandLine(argv)
@@ -1015,7 +1020,7 @@ int main(int argc, char** argv) {
 	if (fMonotoneType3) fMonotoneTypeID=3;
 
 	// Call the actual mesh generator
-    OfflineMap mapRemap;
+	OfflineMap mapRemap;
 	int err = GenerateOfflineMap(  mapRemap, strInputMesh, strOutputMesh, strOverlapMesh,
                                     strSourceMeta, strTargetMeta,
                                     strSourceType, strTargetType,
@@ -1024,7 +1029,7 @@ int main(int argc, char** argv) {
                                     fVolumetric, fNoConservation, fNoCheck,
                                     strVariables, strOutputMap, strInputData, strOutputData,
                                     strNColName, fOutputDouble, strOutputFormat, strPreserveVariables, fPreserveAll, dFillValueOverride,
-                                    fSourceConcave, fTargetConcave );
+                                    fSourceConcave, fTargetConcave, fSparseConstraints );
 
 	if (err) exit(err);
 

--- a/src/GenerateOfflineMapExe.cpp
+++ b/src/GenerateOfflineMapExe.cpp
@@ -114,6 +114,9 @@ int main(int argc, char** argv) {
 	// Output mesh contains concave elements
 	bool fOutputConcave;
 
+	// use sparse constraints when forcing conservation and consistency
+	bool fSparseConstraints;
+
 	// Parse the command line
 	BeginCommandLine()
 		CommandLineString(strInputMesh, "in_mesh", "");
@@ -147,6 +150,7 @@ int main(int argc, char** argv) {
 		CommandLineDouble(dFillValueOverride, "fillvalue", 0.0);
 		CommandLineBool(fInputConcave, "in_concave");
 		CommandLineBool(fOutputConcave, "out_concave");
+		CommandLineBool(fSparseConstraints, "sparse_constraints");
 
 		ParseCommandLine(argc, argv);
 	EndCommandLine(argv)
@@ -182,7 +186,8 @@ int main(int argc, char** argv) {
 			strPreserveVariables,
 			fPreserveAll,
 			dFillValueOverride,
-			fInputConcave, fOutputConcave);
+			fInputConcave, fOutputConcave,
+			fSparseConstraints);
 
 	if (err) exit(err);
 

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -685,10 +685,14 @@ void ForceConsistencyConservation3(
 #ifdef DO_NOT_USE_DC_MATRIX
 
 	for (int i = 0; i < nCondConsistency; i++)
+	{
 	    for (int j = 0; j < nCondConservation - 1; j++)
 	        // R^_ij =  R_ij - lambda_i - kapa_j * JT_i
 	        dCoeff[i][j] =
 	                dCoeff[i][j] - localLK[i] - localLK[nCondConsistency + j] * vecTargetArea[i];
+	    // the last column still needs correction
+	    dCoeff[i][nCondConservation - 1] = dCoeff[i][nCondConservation - 1] - localLK[i];
+	}
 	// Obtain coefficients
 #else
 	trans = 't';

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -704,7 +704,7 @@ void ForceConsistencyConservation3(
 		&posone,
 		&(dRHS[0]),
 		&incy);
-	 	// Store coefficients in array
+		// Store coefficients in array
 		ix = 0;
 		for (int i = 0; i < dCoeff.GetRows(); i++) {
 			for (int j = 0; j < dCoeff.GetColumns(); j++) {
@@ -766,7 +766,7 @@ void LinearRemapSE4(
 	const DataArray3D<double> & dataGLLJacobian,
 	int nMonotoneType,
 	bool fContinuousIn,
-	bool fNoConservation,
+	bool fNoConservation, bool useSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 	// Order of the polynomial interpolant
@@ -1067,7 +1067,8 @@ void LinearRemapSE4(
 					vecSourceArea,
 					vecTargetArea,
 					dCoeff,
-					(nMonotoneType != 0));
+					(nMonotoneType != 0),
+					useSparseConstraints);
 
 			// If too many target faces are included this can greatly slow down the computation and
 			// require a high memory footprint.  In this case only apply forcing to the first
@@ -1120,7 +1121,8 @@ void LinearRemapSE4(
 					vecSourceArea,
 					dSubsetTargetArea,
 					dSubsetCoeff,
-					(nMonotoneType != 0));
+					(nMonotoneType != 0),
+					useSparseConstraints);
 
 				for (int j = 0; j < FORCECC_MAX_TARGET_FACES; j++) {
 					for (int p = 0; p < nP; p++) {
@@ -1194,6 +1196,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
+	bool useSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 
@@ -1563,7 +1566,8 @@ void LinearRemapGLLtoGLL_Pointwise(
 			dSourceArea,
 			dTargetArea,
 			dCoeff,
-			(nMonotoneType != 0));
+			(nMonotoneType != 0),
+			useSparseConstraints);
 
 		for (int i = 0; i < nOverlapFaces; i++) {
 			int ixSecondFace = meshOverlap.vecTargetFaceIx[ixOverlap + i];
@@ -1668,7 +1672,8 @@ void LinearRemapGLLtoGLL_Pointwise(
 			dSourceArea,
 			dTargetArea,
 			dCoeff,
-			(nMonotoneType != 0));
+			(nMonotoneType != 0),
+			useSparseConstraints);
 
 /*
 		// Check column sums (conservation)
@@ -1807,6 +1812,7 @@ void LinearRemapGLLtoGLL_Integrated(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
+	bool useSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 	// Triangular quadrature rule
@@ -2077,7 +2083,8 @@ void LinearRemapGLLtoGLL_Integrated(
 			dSourceArea,
 			dTargetArea,
 			dCoeff,
-			(nMonotoneType != 0));
+			(nMonotoneType != 0),
+			useSparseConstraints);
 
 		for (int i = 0; i < nOverlapFaces; i++) {
 			int ixSecondFace = meshOverlap.vecTargetFaceIx[ixOverlap + i];
@@ -2182,7 +2189,8 @@ void LinearRemapGLLtoGLL_Integrated(
 			dSourceArea,
 			dTargetArea,
 			dCoeff,
-			(nMonotoneType != 0));
+			(nMonotoneType != 0),
+			useSparseConstraints);
 /*
 		// Check column sums (conservation)
 		for (int i = 0; i < dCoeff.GetColumns(); i++) {

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -506,7 +506,7 @@ void ForceConsistencyConservation3(
 	const DataArray1D<double> & vecSourceArea,
 	const DataArray1D<double> & vecTargetArea,
 	DataArray2D<double> & dCoeff,
-	bool fMonotone, bool useSparseConstraints = false
+	bool fMonotone, bool fSparseConstraints = false
 ) {
 
 	// Number of free coefficients
@@ -526,7 +526,7 @@ void ForceConsistencyConservation3(
 	// RHS
 	DataArray1D<double> dRHS; // (nCoeff + nCond);
 	int ix = 0;
-	if (useSparseConstraints) 
+	if (fSparseConstraints)
 		localLK.Allocate(nCond); // will store lagrange multipliers lambda(nCondConservation)
 	                         // and kappa(nCond-1)
 	else {
@@ -540,7 +540,7 @@ void ForceConsistencyConservation3(
 		}
 	}
 	
-	if (!useSparseConstraints){
+	if (!fSparseConstraints){
 		// Consistency
 		ix = 0;
 		for (int i = 0; i < dCoeff.GetRows(); i++) {
@@ -607,7 +607,7 @@ void ForceConsistencyConservation3(
 	int incy = 1;
 	double posone = 1.0;
 	double negone = -1.0;
-	if (useSparseConstraints)
+	if (fSparseConstraints)
 	{
 		for (int m=0; m < nCondConsistency; m++) { // consistency condition
 			localLK[m] = 0;
@@ -656,7 +656,7 @@ void ForceConsistencyConservation3(
 		&nInfo);
 */
 	char uplo = 'U';
-	if (useSparseConstraints)
+	if (fSparseConstraints)
 		dposv_(
 		&uplo,
 		&m,
@@ -679,7 +679,7 @@ void ForceConsistencyConservation3(
 	if (nInfo != 0) {
 		_EXCEPTION1("Unable to solve SPD Schur system: %i\n", nInfo);
 	}
-	if (useSparseConstraints) {
+	if (fSparseConstraints) {
 		for (int i = 0; i < nCondConsistency; i++) {
 			for (int j = 0; j < nCondConservation - 1; j++)
 			// R^_ij =  R_ij - lambda_i - kapa_j * JT_i
@@ -766,7 +766,7 @@ void LinearRemapSE4(
 	const DataArray3D<double> & dataGLLJacobian,
 	int nMonotoneType,
 	bool fContinuousIn,
-	bool fNoConservation, bool useSparseConstraints,
+	bool fNoConservation, bool fSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 	// Order of the polynomial interpolant
@@ -1068,7 +1068,7 @@ void LinearRemapSE4(
 					vecTargetArea,
 					dCoeff,
 					(nMonotoneType != 0),
-					useSparseConstraints);
+					fSparseConstraints);
 
 			// If too many target faces are included this can greatly slow down the computation and
 			// require a high memory footprint.  In this case only apply forcing to the first
@@ -1122,7 +1122,7 @@ void LinearRemapSE4(
 					dSubsetTargetArea,
 					dSubsetCoeff,
 					(nMonotoneType != 0),
-					useSparseConstraints);
+					fSparseConstraints);
 
 				for (int j = 0; j < FORCECC_MAX_TARGET_FACES; j++) {
 					for (int p = 0; p < nP; p++) {
@@ -1196,7 +1196,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
-	bool useSparseConstraints,
+	bool fSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 
@@ -1567,7 +1567,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 			dTargetArea,
 			dCoeff,
 			(nMonotoneType != 0),
-			useSparseConstraints);
+			fSparseConstraints);
 
 		for (int i = 0; i < nOverlapFaces; i++) {
 			int ixSecondFace = meshOverlap.vecTargetFaceIx[ixOverlap + i];
@@ -1673,7 +1673,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 			dTargetArea,
 			dCoeff,
 			(nMonotoneType != 0),
-			useSparseConstraints);
+			fSparseConstraints);
 
 /*
 		// Check column sums (conservation)
@@ -1812,7 +1812,7 @@ void LinearRemapGLLtoGLL_Integrated(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
-	bool useSparseConstraints,
+	bool fSparseConstraints,
 	OfflineMap & mapRemap
 ) {
 	// Triangular quadrature rule
@@ -2084,7 +2084,7 @@ void LinearRemapGLLtoGLL_Integrated(
 			dTargetArea,
 			dCoeff,
 			(nMonotoneType != 0),
-			useSparseConstraints);
+			fSparseConstraints);
 
 		for (int i = 0; i < nOverlapFaces; i++) {
 			int ixSecondFace = meshOverlap.vecTargetFaceIx[ixOverlap + i];
@@ -2190,7 +2190,7 @@ void LinearRemapGLLtoGLL_Integrated(
 			dTargetArea,
 			dCoeff,
 			(nMonotoneType != 0),
-			useSparseConstraints);
+			fSparseConstraints);
 /*
 		// Check column sums (conservation)
 		for (int i = 0; i < dCoeff.GetColumns(); i++) {

--- a/src/LinearRemapSE0.h
+++ b/src/LinearRemapSE0.h
@@ -54,7 +54,7 @@ void LinearRemapSE4(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fNoConservation,
-	bool useSparseConstraints,
+	bool fSparseConstraints,
 	OfflineMap & mapRemap
 );
 
@@ -78,7 +78,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
-	bool useSparseConstraints,
+	bool fSparseConstraints,
 	OfflineMap & mapRemap
 );
 
@@ -102,7 +102,7 @@ void LinearRemapGLLtoGLL_Integrated(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
-	bool useSparseConstraints,
+	bool fSparseConstraints,
 	OfflineMap & mapRemap
 );
 

--- a/src/LinearRemapSE0.h
+++ b/src/LinearRemapSE0.h
@@ -54,6 +54,7 @@ void LinearRemapSE4(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fNoConservation,
+	bool useSparseConstraints,
 	OfflineMap & mapRemap
 );
 
@@ -77,6 +78,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
+	bool useSparseConstraints,
 	OfflineMap & mapRemap
 );
 
@@ -100,6 +102,7 @@ void LinearRemapGLLtoGLL_Integrated(
 	int nMonotoneType,
 	bool fContinuousIn,
 	bool fContinuousOut,
+	bool useSparseConstraints,
 	OfflineMap & mapRemap
 );
 

--- a/src/TempestRemapAPI.h
+++ b/src/TempestRemapAPI.h
@@ -199,7 +199,8 @@ extern "C" {
 		bool fPreserveAll = false,
 		double dFillValueOverride = 0.0,
 		bool fInputConcave = false,
-		bool fOutputConcave = false );
+		bool fOutputConcave = false,
+		bool fSparseConstraints = false);
 
 	// Generate the OfflineMap between input and output meshes
 	int GenerateOfflineMapWithMeshes (
@@ -230,7 +231,8 @@ extern "C" {
 		bool fPreserveAll = false,
 		double dFillValueOverride = 0.0,
 		bool fInputConcave = false,
-		bool fOutputConcave = false );
+		bool fOutputConcave = false,
+		bool fSparseConstraints = false);
 
 	// Apply an offline map to a datafile
 	int ApplyOfflineMap(


### PR DESCRIPTION
dC is a matrix of size nCoeff x nCond, very sparse
for high number of intersection polygons, (~20k), this matrix dC size is about 200k x 20k, which is unreasonable
no need to use blas dgemv for that multiplication, all loops can be unrolled

change can be tested by commenting out 
#define DO_NOT_USE_DC_MATRIX 