### PR TITLE
center decomposition in triangles

### DIFF
--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -365,48 +365,47 @@ void BuildIntegrationArray(
 
 	// Loop through all overlap Faces
 	for (int i = 0; i < nOverlapFaces; i++) {
-		const Face & faceOverlap = meshOverlap.faces[ixOverlapBegin + i];
+		const Face &faceOverlap = meshOverlap.faces[ixOverlapBegin + i];
 
-		const NodeVector & nodesOverlap = meshOverlap.nodes;
+		const NodeVector &nodesOverlap = meshOverlap.nodes;
 
 		int nbEdges = faceOverlap.edges.size();
-        int nOverlapTriangles = 1;
-        Node center; // not used if nbEdges == 3
-        if (nbEdges > 3) { // decompose from center in this case
-            nOverlapTriangles = nbEdges;
-            for (int k = 0; k < nbEdges; k++) {
-                const Node &node = nodesOverlap[faceOverlap[k]];
-                center = center + node;
-            }
-            center = center / nbEdges;
-            double magni = sqrt(
-                    center.x * center.x + center.y * center.y
-                            + center.z * center.z);
-            center = center / magni; // project back on sphere of radius 1
-        }
+		int nOverlapTriangles = 1;
+		Node center; // not used if nbEdges == 3
+		if (nbEdges > 3) { // decompose from center in this case
+			nOverlapTriangles = nbEdges;
+			for (int k = 0; k < nbEdges; k++) {
+				const Node &node = nodesOverlap[faceOverlap[k]];
+				center = center + node;
+			}
+			center = center / nbEdges;
+			double magni = sqrt(
+					center.x * center.x + center.y * center.y
+							+ center.z * center.z);
+			center = center / magni; // project back on sphere of radius 1
+		}
 
-        Node node0, node1, node2;
-        double dTriArea;
+		Node node0, node1, node2;
+		double dTriArea;
 
 		// Loop over all sub-triangles of this Overlap Face
 		for (int j = 0; j < nOverlapTriangles; j++) {
 
-		    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-            {
-                node0 = nodesOverlap[faceOverlap[0]];
-                node1 = nodesOverlap[faceOverlap[1]];
-                node2 = nodesOverlap[faceOverlap[2]];
-
-            }
-            else // decompose polygon in triangles around the center
-            {
-                node0 = center;
-                node1 = nodesOverlap[faceOverlap[j]];
-                int j1 = (j + 1) % nbEdges;
-                node2 = nodesOverlap[faceOverlap[j1]];
-            }
-
-            dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+			if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+			{
+				node0 = nodesOverlap[faceOverlap[0]];
+				node1 = nodesOverlap[faceOverlap[1]];
+				node2 = nodesOverlap[faceOverlap[2]];
+			}
+			else // decompose polygon in triangles around the center
+			{
+				node0 = center;
+				node1 = nodesOverlap[faceOverlap[j]];
+				int j1 = (j + 1) % nbEdges;
+				node2 = nodesOverlap[faceOverlap[j1]];
+			}
+			dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1,
+					node2);
 
 			for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -369,24 +369,44 @@ void BuildIntegrationArray(
 
 		const NodeVector & nodesOverlap = meshOverlap.nodes;
 
-		int nOverlapTriangles = faceOverlap.edges.size() - 2;
+		int nbEdges = faceOverlap.edges.size();
+        int nOverlapTriangles = 1;
+        Node center; // not used if nbEdges == 3
+        if (nbEdges > 3) { // decompose from center in this case
+            nOverlapTriangles = nbEdges;
+            for (int k = 0; k < nbEdges; k++) {
+                const Node &node = nodesOverlap[faceOverlap[k]];
+                center = center + node;
+            }
+            center = center / nbEdges;
+            double magni = sqrt(
+                    center.x * center.x + center.y * center.y
+                            + center.z * center.z);
+            center = center / magni; // project back on sphere of radius 1
+        }
+
+        Node node0, node1, node2;
+        double dTriArea;
 
 		// Loop over all sub-triangles of this Overlap Face
 		for (int j = 0; j < nOverlapTriangles; j++) {
 
-			// Cornerpoints of triangle
-			const Node & node0 = nodesOverlap[faceOverlap[0]];
-			const Node & node1 = nodesOverlap[faceOverlap[j+1]];
-			const Node & node2 = nodesOverlap[faceOverlap[j+2]];
+		    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+            {
+                node0 = nodesOverlap[faceOverlap[0]];
+                node1 = nodesOverlap[faceOverlap[1]];
+                node2 = nodesOverlap[faceOverlap[2]];
 
-			// Calculate the area of the modified Face
-			Face faceTri(3);
-			faceTri.SetNode(0, faceOverlap[0]);
-			faceTri.SetNode(1, faceOverlap[j+1]);
-			faceTri.SetNode(2, faceOverlap[j+2]);
+            }
+            else // decompose polygon in triangles around the center
+            {
+                node0 = center;
+                node1 = nodesOverlap[faceOverlap[j]];
+                int j1 = (j + 1) % nbEdges;
+                node2 = nodesOverlap[faceOverlap[j1]];
+            }
 
-			double dTriArea =
-				CalculateFaceArea(faceTri, nodesOverlap);
+            dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 
 			for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -371,18 +371,18 @@ void BuildIntegrationArray(
 
 		int nbEdges = faceOverlap.edges.size();
 		int nOverlapTriangles = 1;
-		Node center; // not used if nbEdges == 3
+		Node nodeCenter; // not used if nbEdges == 3
 		if (nbEdges > 3) { // decompose from center in this case
 			nOverlapTriangles = nbEdges;
 			for (int k = 0; k < nbEdges; k++) {
-				const Node &node = nodesOverlap[faceOverlap[k]];
-				center = center + node;
+				const Node & currNode = nodesOverlap[faceOverlap[k]];
+				nodeCenter = nodeCenter + currNode;
 			}
-			center = center / nbEdges;
-			double magni = sqrt(
-					center.x * center.x + center.y * center.y
-							+ center.z * center.z);
-			center = center / magni; // project back on sphere of radius 1
+			nodeCenter = nodeCenter / nbEdges;
+			double dMagni = sqrt(
+					nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+							+ nodeCenter.z * nodeCenter.z);
+			nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 		}
 
 		Node node0, node1, node2;
@@ -391,15 +391,13 @@ void BuildIntegrationArray(
 		// Loop over all sub-triangles of this Overlap Face
 		for (int j = 0; j < nOverlapTriangles; j++) {
 
-			if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-			{
+			if (nbEdges == 3) {
 				node0 = nodesOverlap[faceOverlap[0]];
 				node1 = nodesOverlap[faceOverlap[1]];
 				node2 = nodesOverlap[faceOverlap[2]];
 			}
-			else // decompose polygon in triangles around the center
-			{
-				node0 = center;
+			else { // decompose polygon in triangles around the center
+				node0 = nodeCenter;
 				node1 = nodesOverlap[faceOverlap[j]];
 				int j1 = (j + 1) % nbEdges;
 				node2 = nodesOverlap[faceOverlap[j1]];

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -1788,80 +1788,78 @@ int BuildCoincidentNodeVector(
 	return nCoincidentNodes;
 }
 
-Real CalculateTriangleAreaQuadratureMethod(
-    Node node1, Node node2, Node node3
-) {
+Real CalculateTriangleAreaQuadratureMethod(Node &node1, Node &node2,
+		Node &node3) {
 
-    const int nOrder = 6;
+	const int nOrder = 6;
 
-    DataArray1D<double> dG;
-    DataArray1D<double> dW;
-    GaussQuadrature::GetPoints(nOrder, 0.0, 1.0, dG, dW);
+	DataArray1D<double> dG;
+	DataArray1D<double> dW;
+	GaussQuadrature::GetPoints(nOrder, 0.0, 1.0, dG, dW);
 
-    double dArea = 0.0;
-    // Calculate area at quadrature node
-    for (int p = 0; p < dW.GetRows(); p++) {
-        for (int q = 0; q < dW.GetRows(); q++) {
+	double dArea = 0.0;
+	// Calculate area at quadrature node
+	for (int p = 0; p < dW.GetRows(); p++) {
+		for (int q = 0; q < dW.GetRows(); q++) {
 
-            double dA = dG[p];
-            double dB = dG[q];
+			double dA = dG[p];
+			double dB = dG[q];
 
-            Node dF(
-                (1.0 - dB) * ((1.0 - dA) * node1.x + dA * node2.x) + dB * node3.x,
-                (1.0 - dB) * ((1.0 - dA) * node1.y + dA * node2.y) + dB * node3.y,
-                (1.0 - dB) * ((1.0 - dA) * node1.z + dA * node2.z) + dB * node3.z);
+			Node dF(
+					(1.0 - dB) * ((1.0 - dA) * node1.x + dA * node2.x)
+							+ dB * node3.x,
+					(1.0 - dB) * ((1.0 - dA) * node1.y + dA * node2.y)
+							+ dB * node3.y,
+					(1.0 - dB) * ((1.0 - dA) * node1.z + dA * node2.z)
+							+ dB * node3.z);
 
-            Node dDaF(
-                (1.0 - dB) * (node2.x - node1.x),
-                (1.0 - dB) * (node2.y - node1.y),
-                (1.0 - dB) * (node2.z - node1.z));
+			Node dDaF((1.0 - dB) * (node2.x - node1.x),
+					(1.0 - dB) * (node2.y - node1.y),
+					(1.0 - dB) * (node2.z - node1.z));
 
-            Node dDbF(
-                - (1.0 - dA) * node1.x - dA * node2.x + node3.x,
-                - (1.0 - dA) * node1.y - dA * node2.y + node3.y,
-                - (1.0 - dA) * node1.z - dA * node2.z + node3.z);
+			Node dDbF(-(1.0 - dA) * node1.x - dA * node2.x + node3.x,
+					-(1.0 - dA) * node1.y - dA * node2.y + node3.y,
+					-(1.0 - dA) * node1.z - dA * node2.z + node3.z);
 
-            double dR = sqrt(dF.x * dF.x + dF.y * dF.y + dF.z * dF.z);
+			double dR = sqrt(dF.x * dF.x + dF.y * dF.y + dF.z * dF.z);
 
-            Node dDaG(
-                dDaF.x * (dF.y * dF.y + dF.z * dF.z)
-                    - dF.x * (dDaF.y * dF.y + dDaF.z * dF.z),
-                dDaF.y * (dF.x * dF.x + dF.z * dF.z)
-                    - dF.y * (dDaF.x * dF.x + dDaF.z * dF.z),
-                dDaF.z * (dF.x * dF.x + dF.y * dF.y)
-                    - dF.z * (dDaF.x * dF.x + dDaF.y * dF.y));
+			Node dDaG(
+					dDaF.x * (dF.y * dF.y + dF.z * dF.z)
+							- dF.x * (dDaF.y * dF.y + dDaF.z * dF.z),
+					dDaF.y * (dF.x * dF.x + dF.z * dF.z)
+							- dF.y * (dDaF.x * dF.x + dDaF.z * dF.z),
+					dDaF.z * (dF.x * dF.x + dF.y * dF.y)
+							- dF.z * (dDaF.x * dF.x + dDaF.y * dF.y));
 
-            Node dDbG(
-                dDbF.x * (dF.y * dF.y + dF.z * dF.z)
-                    - dF.x * (dDbF.y * dF.y + dDbF.z * dF.z),
-                dDbF.y * (dF.x * dF.x + dF.z * dF.z)
-                    - dF.y * (dDbF.x * dF.x + dDbF.z * dF.z),
-                dDbF.z * (dF.x * dF.x + dF.y * dF.y)
-                    - dF.z * (dDbF.x * dF.x + dDbF.y * dF.y));
+			Node dDbG(
+					dDbF.x * (dF.y * dF.y + dF.z * dF.z)
+							- dF.x * (dDbF.y * dF.y + dDbF.z * dF.z),
+					dDbF.y * (dF.x * dF.x + dF.z * dF.z)
+							- dF.y * (dDbF.x * dF.x + dDbF.z * dF.z),
+					dDbF.z * (dF.x * dF.x + dF.y * dF.y)
+							- dF.z * (dDbF.x * dF.x + dDbF.y * dF.y));
 
-            double dDenomTerm = 1.0 / (dR * dR * dR);
+			double dDenomTerm = 1.0 / (dR * dR * dR);
 
-            dDaG.x *= dDenomTerm;
-            dDaG.y *= dDenomTerm;
-            dDaG.z *= dDenomTerm;
+			dDaG.x *= dDenomTerm;
+			dDaG.y *= dDenomTerm;
+			dDaG.z *= dDenomTerm;
 
-            dDbG.x *= dDenomTerm;
-            dDbG.y *= dDenomTerm;
-            dDbG.z *= dDenomTerm;
+			dDbG.x *= dDenomTerm;
+			dDbG.y *= dDenomTerm;
+			dDbG.z *= dDenomTerm;
 
-            // Cross product gives local Jacobian
-            Node nodeCross = CrossProduct(dDaG, dDbG);
+			// Cross product gives local Jacobian
+			Node nodeCross = CrossProduct(dDaG, dDbG);
 
-            double dJacobian = sqrt(
-                  nodeCross.x * nodeCross.x
-                + nodeCross.y * nodeCross.y
-                + nodeCross.z * nodeCross.z);
+			double dJacobian = sqrt(
+					nodeCross.x * nodeCross.x + nodeCross.y * nodeCross.y
+							+ nodeCross.z * nodeCross.z);
 
-
-            dArea += dW[p] * dW[q] * dJacobian;
-        }
-    }
-    return dArea;
+			dArea += dW[p] * dW[q] * dJacobian;
+		}
+	}
+	return dArea;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -1788,8 +1788,8 @@ int BuildCoincidentNodeVector(
 	return nCoincidentNodes;
 }
 
-Real CalculateTriangleAreaQuadratureMethod(Node &node1, Node &node2,
-		Node &node3) {
+Real CalculateTriangleAreaQuadratureMethod(Node & node1, Node & node2,
+		Node & node3) {
 
 	const int nOrder = 6;
 

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -1788,6 +1788,82 @@ int BuildCoincidentNodeVector(
 	return nCoincidentNodes;
 }
 
+Real CalculateTriangleAreaQuadratureMethod(
+    Node node1, Node node2, Node node3
+) {
+
+    const int nOrder = 6;
+
+    DataArray1D<double> dG;
+    DataArray1D<double> dW;
+    GaussQuadrature::GetPoints(nOrder, 0.0, 1.0, dG, dW);
+
+    double dArea = 0.0;
+    // Calculate area at quadrature node
+    for (int p = 0; p < dW.GetRows(); p++) {
+        for (int q = 0; q < dW.GetRows(); q++) {
+
+            double dA = dG[p];
+            double dB = dG[q];
+
+            Node dF(
+                (1.0 - dB) * ((1.0 - dA) * node1.x + dA * node2.x) + dB * node3.x,
+                (1.0 - dB) * ((1.0 - dA) * node1.y + dA * node2.y) + dB * node3.y,
+                (1.0 - dB) * ((1.0 - dA) * node1.z + dA * node2.z) + dB * node3.z);
+
+            Node dDaF(
+                (1.0 - dB) * (node2.x - node1.x),
+                (1.0 - dB) * (node2.y - node1.y),
+                (1.0 - dB) * (node2.z - node1.z));
+
+            Node dDbF(
+                - (1.0 - dA) * node1.x - dA * node2.x + node3.x,
+                - (1.0 - dA) * node1.y - dA * node2.y + node3.y,
+                - (1.0 - dA) * node1.z - dA * node2.z + node3.z);
+
+            double dR = sqrt(dF.x * dF.x + dF.y * dF.y + dF.z * dF.z);
+
+            Node dDaG(
+                dDaF.x * (dF.y * dF.y + dF.z * dF.z)
+                    - dF.x * (dDaF.y * dF.y + dDaF.z * dF.z),
+                dDaF.y * (dF.x * dF.x + dF.z * dF.z)
+                    - dF.y * (dDaF.x * dF.x + dDaF.z * dF.z),
+                dDaF.z * (dF.x * dF.x + dF.y * dF.y)
+                    - dF.z * (dDaF.x * dF.x + dDaF.y * dF.y));
+
+            Node dDbG(
+                dDbF.x * (dF.y * dF.y + dF.z * dF.z)
+                    - dF.x * (dDbF.y * dF.y + dDbF.z * dF.z),
+                dDbF.y * (dF.x * dF.x + dF.z * dF.z)
+                    - dF.y * (dDbF.x * dF.x + dDbF.z * dF.z),
+                dDbF.z * (dF.x * dF.x + dF.y * dF.y)
+                    - dF.z * (dDbF.x * dF.x + dDbF.y * dF.y));
+
+            double dDenomTerm = 1.0 / (dR * dR * dR);
+
+            dDaG.x *= dDenomTerm;
+            dDaG.y *= dDenomTerm;
+            dDaG.z *= dDenomTerm;
+
+            dDbG.x *= dDenomTerm;
+            dDbG.y *= dDenomTerm;
+            dDbG.z *= dDenomTerm;
+
+            // Cross product gives local Jacobian
+            Node nodeCross = CrossProduct(dDaG, dDbG);
+
+            double dJacobian = sqrt(
+                  nodeCross.x * nodeCross.x
+                + nodeCross.y * nodeCross.y
+                + nodeCross.z * nodeCross.z);
+
+
+            dArea += dW[p] * dW[q] * dJacobian;
+        }
+    }
+    return dArea;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 Real CalculateSphericalTriangleJacobian(

--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -1022,6 +1022,12 @@ Real CalculateFaceArea(
 	const NodeVector & nodes
 );
 
+/// <summary>
+///     Calculate triangle area, quadrature.
+/// </summary>
+Real CalculateTriangleAreaQuadratureMethod(
+    Node node1, Node node2, Node node3
+);
 ///////////////////////////////////////////////////////////////////////////////
 
 ///	<summary>

--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -1026,7 +1026,9 @@ Real CalculateFaceArea(
 ///     Calculate triangle area, quadrature.
 /// </summary>
 Real CalculateTriangleAreaQuadratureMethod(
-    Node node1, Node node2, Node node3
+	Node &node1,
+	Node &node2,
+	Node &node3
 );
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/LinearRemapFV.cpp
+++ b/src/LinearRemapFV.cpp
@@ -1683,17 +1683,6 @@ void LinearRemapFVtoGLL(
 	// Loop through all faces on meshInput
 	ixOverlap = 0;
 
-    // generic triangle used for area computation, for triangles around the center of overlap face;
-    // used for overlap faces with more than 4 edges;
-    // nodes array will be set for each triangle;
-    // these triangles are not part of the mesh structure, they are just temporary during
-    //   aforementioned decomposition.
-    Face faceTri( 3 );
-    NodeVector nodes( 3 );
-    faceTri.SetNode( 0, 0 );
-    faceTri.SetNode( 1, 1 );
-    faceTri.SetNode( 2, 2 );
-
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
 		// Output every 100 elements
@@ -1766,7 +1755,6 @@ void LinearRemapFVtoGLL(
                     node0 = nodesOverlap[faceOverlap[0]];
                     node1 = nodesOverlap[faceOverlap[1]];
                     node2 = nodesOverlap[faceOverlap[2]];
-                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
                 }
                 else // decompose polygon in triangles around the center
                 {
@@ -1774,12 +1762,8 @@ void LinearRemapFVtoGLL(
                     node1 = nodesOverlap[faceOverlap[j]];
                     int j1 = (j + 1) % nbEdges;
                     node2 = nodesOverlap[faceOverlap[j1]];
-                    nodes[0] = center;
-                    nodes[1] = node1;
-                    nodes[2] = node2;
-                    dTriArea = CalculateFaceArea(faceTri, nodes);
                 }
-
+			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 
 					// Get the nodal location of this point
@@ -2401,17 +2385,6 @@ void LinearRemapGLLtoGLL2(
 	// Loop through all faces on meshInput
 	ixOverlap = 0;
 
-	// generic triangle used for area computation, for triangles around the center of overlap face;
-    // used for overlap faces with more than 4 edges;
-    // nodes array will be set for each triangle;
-    // these triangles are not part of the mesh structure, they are just temporary during
-    //   aforementioned decomposition.
-    Face faceTri( 3 );
-    NodeVector nodes( 3 );
-    faceTri.SetNode( 0, 0 );
-    faceTri.SetNode( 1, 1 );
-    faceTri.SetNode( 2, 2 );
-
 	Announce("Building conservative distribution maps");
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
@@ -2478,7 +2451,6 @@ void LinearRemapGLLtoGLL2(
                     node0 = nodesOverlap[faceOverlap[0]];
                     node1 = nodesOverlap[faceOverlap[1]];
                     node2 = nodesOverlap[faceOverlap[2]];
-                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
                 }
                 else // decompose polygon in triangles around the center
                 {
@@ -2486,11 +2458,8 @@ void LinearRemapGLLtoGLL2(
                     node1 = nodesOverlap[faceOverlap[j]];
                     int j1 = (j + 1) % nbEdges;
                     node2 = nodesOverlap[faceOverlap[j1]];
-                    nodes[0] = center;
-                    nodes[1] = node1;
-                    nodes[2] = node2;
-                    dTriArea = CalculateFaceArea(faceTri, nodes);
                 }
+			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/LinearRemapFV.cpp
+++ b/src/LinearRemapFV.cpp
@@ -1751,7 +1751,7 @@ void LinearRemapFVtoGLL(
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
 				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-						{
+				{
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
@@ -2442,7 +2442,7 @@ void LinearRemapGLLtoGLL2(
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
 				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-						{
+				{
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];

--- a/src/LinearRemapFV.cpp
+++ b/src/LinearRemapFV.cpp
@@ -1719,51 +1719,51 @@ void LinearRemapFVtoGLL(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector & nodesOverlap = meshOverlap.nodes;
+			const NodeVector &nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector & nodesSecond = meshOutput.nodes;
+			const NodeVector &nodesSecond = meshOutput.nodes;
 
-			const Face & faceSecond = meshOutput.faces[ixSecond];
+			const Face &faceSecond = meshOutput.faces[ixSecond];
 			int nbEdges = faceOverlap.edges.size();
-            int nOverlapTriangles = 1;
-            Node center; // not used if nbEdges == 3
-            if (nbEdges > 3) { // decompose from center in this case
-                nOverlapTriangles = nbEdges;
-                for (int k = 0; k < nbEdges; k++) {
-                    const Node &node = nodesOverlap[faceOverlap[k]];
-                    center = center + node;
-                }
-                center = center / nbEdges;
-                double magni = sqrt(
-                        center.x * center.x + center.y * center.y
-                                + center.z * center.z);
-                center = center / magni; // project back on sphere of radius 1
-            }
+			int nOverlapTriangles = 1;
+			Node center; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from center in this case
+				nOverlapTriangles = nbEdges;
+				for (int k = 0; k < nbEdges; k++) {
+					const Node &node = nodesOverlap[faceOverlap[k]];
+					center = center + node;
+				}
+				center = center / nbEdges;
+				double magni = sqrt(
+						center.x * center.x + center.y * center.y
+								+ center.z * center.z);
+				center = center / magni; // project back on sphere of radius 1
+			}
 
-            Node node0, node1, node2;
-            double dTriArea;
+			Node node0, node1, node2;
+			double dTriArea;
 			// Loop over all sub-triangles of this Overlap Face
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
-			    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-                {
-                    node0 = nodesOverlap[faceOverlap[0]];
-                    node1 = nodesOverlap[faceOverlap[1]];
-                    node2 = nodesOverlap[faceOverlap[2]];
-                }
-                else // decompose polygon in triangles around the center
-                {
-                    node0 = center;
-                    node1 = nodesOverlap[faceOverlap[j]];
-                    int j1 = (j + 1) % nbEdges;
-                    node2 = nodesOverlap[faceOverlap[j1]];
-                }
-			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+						{
+					node0 = nodesOverlap[faceOverlap[0]];
+					node1 = nodesOverlap[faceOverlap[1]];
+					node2 = nodesOverlap[faceOverlap[2]];
+				} else // decompose polygon in triangles around the center
+				{
+					node0 = center;
+					node1 = nodesOverlap[faceOverlap[j]];
+					int j1 = (j + 1) % nbEdges;
+					node2 = nodesOverlap[faceOverlap[j1]];
+				}
+				dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1,
+						node2);
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 
 					// Get the nodal location of this point
@@ -2414,52 +2414,47 @@ void LinearRemapGLLtoGLL2(
 
 			// Quantities from the overlap Mesh
 			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
-
 			const NodeVector & nodesOverlap = meshOverlap.nodes;
-
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
-
 			const NodeVector & nodesSecond = meshOutput.nodes;
-
 			const Face & faceSecond = meshOutput.faces[ixSecond];
-
 			int nbEdges = faceOverlap.edges.size();
-            int nOverlapTriangles = 1;
-            Node center; // not used if nbEdges == 3
-            if (nbEdges > 3) { // decompose from center in this case
-                nOverlapTriangles = nbEdges;
-                for (int k = 0; k < nbEdges; k++) {
-                    const Node &node = nodesOverlap[faceOverlap[k]];
-                    center = center + node;
-                }
-                center = center / nbEdges;
-                double magni = sqrt(
-                        center.x * center.x + center.y * center.y
-                                + center.z * center.z);
-                center = center / magni; // project back on sphere of radius 1
-            }
+			int nOverlapTriangles = 1;
+			Node center; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from center in this case
+				nOverlapTriangles = nbEdges;
+				for (int k = 0; k < nbEdges; k++) {
+					const Node &node = nodesOverlap[faceOverlap[k]];
+					center = center + node;
+				}
+				center = center / nbEdges;
+				double magni = sqrt(
+						center.x * center.x + center.y * center.y
+								+ center.z * center.z);
+				center = center / magni; // project back on sphere of radius 1
+			}
 
-            Node node0, node1, node2;
-            double dTriArea;
+			Node node0, node1, node2;
+			double dTriArea;
 
 			// Loop over all sub-triangles of this Overlap Face
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
-			    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-                {
-                    node0 = nodesOverlap[faceOverlap[0]];
-                    node1 = nodesOverlap[faceOverlap[1]];
-                    node2 = nodesOverlap[faceOverlap[2]];
-                }
-                else // decompose polygon in triangles around the center
-                {
-                    node0 = center;
-                    node1 = nodesOverlap[faceOverlap[j]];
-                    int j1 = (j + 1) % nbEdges;
-                    node2 = nodesOverlap[faceOverlap[j1]];
-                }
-			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+						{
+					node0 = nodesOverlap[faceOverlap[0]];
+					node1 = nodesOverlap[faceOverlap[1]];
+					node2 = nodesOverlap[faceOverlap[2]];
+				} else // decompose polygon in triangles around the center
+				{
+					node0 = center;
+					node1 = nodesOverlap[faceOverlap[j]];
+					int j1 = (j + 1) % nbEdges;
+					node2 = nodesOverlap[faceOverlap[j1]];
+				}
+				dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1,
+						node2);
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/LinearRemapFV.cpp
+++ b/src/LinearRemapFV.cpp
@@ -1719,30 +1719,30 @@ void LinearRemapFVtoGLL(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector &nodesOverlap = meshOverlap.nodes;
+			const NodeVector & nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector &nodesSecond = meshOutput.nodes;
+			const NodeVector & nodesSecond = meshOutput.nodes;
 
-			const Face &faceSecond = meshOutput.faces[ixSecond];
+			const Face & faceSecond = meshOutput.faces[ixSecond];
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
-			Node center; // not used if nbEdges == 3
-			if (nbEdges > 3) { // decompose from center in this case
+			Node nodeCenter; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from nodeCenter in this case
 				nOverlapTriangles = nbEdges;
 				for (int k = 0; k < nbEdges; k++) {
 					const Node &node = nodesOverlap[faceOverlap[k]];
-					center = center + node;
+					nodeCenter = nodeCenter + node;
 				}
-				center = center / nbEdges;
-				double magni = sqrt(
-						center.x * center.x + center.y * center.y
-								+ center.z * center.z);
-				center = center / magni; // project back on sphere of radius 1
+				nodeCenter = nodeCenter / nbEdges;
+				double dMagni = sqrt(
+						nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+								+ nodeCenter.z * nodeCenter.z);
+				nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 			}
 
 			Node node0, node1, node2;
@@ -1750,14 +1750,13 @@ void LinearRemapFVtoGLL(
 			// Loop over all sub-triangles of this Overlap Face
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
-				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-				{
+				if (nbEdges == 3) { // will come here only once, nOverlapTriangles == 1 in this case
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
-				} else // decompose polygon in triangles around the center
-				{
-					node0 = center;
+				}
+				else { // decompose polygon in triangles around the nodeCenter
+					node0 = nodeCenter;
 					node1 = nodesOverlap[faceOverlap[j]];
 					int j1 = (j + 1) % nbEdges;
 					node2 = nodesOverlap[faceOverlap[j1]];
@@ -2421,18 +2420,18 @@ void LinearRemapGLLtoGLL2(
 			const Face & faceSecond = meshOutput.faces[ixSecond];
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
-			Node center; // not used if nbEdges == 3
-			if (nbEdges > 3) { // decompose from center in this case
+			Node nodeCenter; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from nodeCenter in this case
 				nOverlapTriangles = nbEdges;
 				for (int k = 0; k < nbEdges; k++) {
 					const Node &node = nodesOverlap[faceOverlap[k]];
-					center = center + node;
+					nodeCenter = nodeCenter + node;
 				}
-				center = center / nbEdges;
-				double magni = sqrt(
-						center.x * center.x + center.y * center.y
-								+ center.z * center.z);
-				center = center / magni; // project back on sphere of radius 1
+				nodeCenter = nodeCenter / nbEdges;
+				double dMagni = sqrt(
+						nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+								+ nodeCenter.z * nodeCenter.z);
+				nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 			}
 
 			Node node0, node1, node2;
@@ -2441,14 +2440,13 @@ void LinearRemapGLLtoGLL2(
 			// Loop over all sub-triangles of this Overlap Face
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
-				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-				{
+				if (nbEdges == 3) { // will come here only once, nOverlapTriangles == 1 in this case
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
-				} else // decompose polygon in triangles around the center
-				{
-					node0 = center;
+				}
+				else { // decompose polygon in triangles around the nodeCenter
+					node0 = nodeCenter;
 					node1 = nodesOverlap[faceOverlap[j]];
 					int j1 = (j + 1) % nbEdges;
 					node2 = nodesOverlap[faceOverlap[j1]];

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -868,11 +868,12 @@ void LinearRemapSE4(
 			// Loop over all sub-triangles of this Overlap Face
 			for (int k = 0; k < nOverlapTriangles; k++) {
 				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-						{
+				{
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
-				} else // decompose polygon in triangles around the center
+				}
+				else // decompose polygon in triangles around the center
 				{
 					node0 = center;
 					node1 = nodesOverlap[faceOverlap[k]];

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -806,16 +806,6 @@ void LinearRemapSE4(
 	// Current Overlap Face
 	int ixOverlap = 0;
 
-	// generic triangle used for area computation, for triangles around the center of overlap face;
-	// used for overlap faces with more than 4 edges;
-	// nodes array will be set for each triangle;
-	// these triangles are not part of the mesh structure, they are just temporary during
-	//   aforementioned decomposition.
-	Face faceTri( 3 );
-	NodeVector nodes( 3 );
-    faceTri.SetNode( 0, 0 );
-    faceTri.SetNode( 1, 1 );
-    faceTri.SetNode( 2, 2 );
 	// Loop over all input Faces
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
@@ -882,7 +872,6 @@ void LinearRemapSE4(
                     node0 = nodesOverlap[faceOverlap[0]];
                     node1 = nodesOverlap[faceOverlap[1]];
                     node2 = nodesOverlap[faceOverlap[2]];
-                    dTriangleArea = CalculateFaceArea(faceOverlap, nodesOverlap);
                 }
                 else // decompose polygon in triangles around the center
                 {
@@ -890,12 +879,8 @@ void LinearRemapSE4(
                     node1 = nodesOverlap[faceOverlap[k]];
                     int k1 = (k + 1) % nbEdges;
                     node2 = nodesOverlap[faceOverlap[k1]];
-                    nodes[0] = center;
-                    nodes[1] = node1;
-                    nodes[2] = node2;
-                    dTriangleArea = CalculateFaceArea(faceTri, nodes);
 	            }
-
+                dTriangleArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 				// Coordinates of quadrature Node
 				for (int l = 0; l < TriQuadraturePoints; l++) {
 					Node nodeQuadrature;
@@ -1250,17 +1235,6 @@ void LinearRemapGLLtoGLL_Pointwise(
 	// Number of overlap Faces per source Face
 	DataArray1D<int> nAllOverlapFaces(meshInput.faces.size());
 
-	// generic triangle used for area computation, for triangles around the center of overlap face;
-    // used for overlap faces with more than 4 edges;
-    // nodes array will be set for each triangle;
-    // these triangles are not part of the mesh structure, they are just temporary during
-    //   aforementioned decomposition.
-    Face faceTri( 3 );
-    NodeVector nodes( 3 );
-    faceTri.SetNode( 0, 0 );
-    faceTri.SetNode( 1, 1 );
-    faceTri.SetNode( 2, 2 );
-
 	int ixOverlap = 0;
 
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
@@ -1347,7 +1321,6 @@ void LinearRemapGLLtoGLL_Pointwise(
                     node0 = nodesOverlap[faceOverlap[0]];
                     node1 = nodesOverlap[faceOverlap[1]];
                     node2 = nodesOverlap[faceOverlap[2]];
-                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
                 }
                 else // decompose polygon in triangles around the center
                 {
@@ -1355,12 +1328,8 @@ void LinearRemapGLLtoGLL_Pointwise(
                     node1 = nodesOverlap[faceOverlap[j]];
                     int j1 = (j + 1) % nbEdges;
                     node2 = nodesOverlap[faceOverlap[j1]];
-                    nodes[0] = center;
-                    nodes[1] = node1;
-                    nodes[2] = node2;
-                    dTriArea = CalculateFaceArea(faceTri, nodes);
                 }
-
+			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 
 					// Get the nodal location of this point
@@ -1927,17 +1896,6 @@ void LinearRemapGLLtoGLL_Integrated(
 
 	std::set< std::pair<int, int> > setFound;
 
-	// generic triangle used for area computation, for triangles around the center of overlap face;
-    // used for overlap faces with more than 4 edges;
-    // nodes array will be set for each triangle;
-    // these triangles are not part of the mesh structure, they are just temporary during
-    //   aforementioned decomposition.
-    Face faceTri( 3 );
-    NodeVector nodes( 3 );
-    faceTri.SetNode( 0, 0 );
-    faceTri.SetNode( 1, 1 );
-    faceTri.SetNode( 2, 2 );
-
     // Loop over all input Faces
 
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
@@ -1996,7 +1954,6 @@ void LinearRemapGLLtoGLL_Integrated(
                     node0 = nodesOverlap[faceOverlap[0]];
                     node1 = nodesOverlap[faceOverlap[1]];
                     node2 = nodesOverlap[faceOverlap[2]];
-                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
                 }
                 else // decompose polygon in triangles around the center
                 {
@@ -2004,11 +1961,8 @@ void LinearRemapGLLtoGLL_Integrated(
                     node1 = nodesOverlap[faceOverlap[k]];
                     int k1 = (k + 1) % nbEdges;
                     node2 = nodesOverlap[faceOverlap[k1]];
-                    nodes[0] = center;
-                    nodes[1] = node1;
-                    nodes[2] = node2;
-                    dTriArea = CalculateFaceArea(faceTri, nodes);
                 }
+                dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -845,42 +845,42 @@ void LinearRemapSE4(
 
 		// Find the local remap coefficients
 		for (int j = 0; j < nOverlapFaces; j++) {
-			const Face & faceOverlap = meshOverlap.faces[ixOverlap + j];
+			const Face &faceOverlap = meshOverlap.faces[ixOverlap + j];
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
 			Node center; // not used if nbEdges == 3
-            if (nbEdges > 3) { // decompose from center in this case
-                nOverlapTriangles = nbEdges;
-                for (int k = 0; k < nbEdges; k++) {
-                    const Node &node = nodesOverlap[faceOverlap[k]];
-                    center = center + node;
-                }
-                center = center / nbEdges;
-                double magni = sqrt(
-                        center.x * center.x + center.y * center.y
-                                + center.z * center.z);
-                center = center / magni; // project back on sphere of radius 1
-            }
+			if (nbEdges > 3) { // decompose from center in this case
+				nOverlapTriangles = nbEdges;
+				for (int k = 0; k < nbEdges; k++) {
+					const Node &node = nodesOverlap[faceOverlap[k]];
+					center = center + node;
+				}
+				center = center / nbEdges;
+				double magni = sqrt(
+						center.x * center.x + center.y * center.y
+								+ center.z * center.z);
+				center = center / magni; // project back on sphere of radius 1
+			}
 
-            Node node0, node1, node2;
-            double dTriangleArea;
+			Node node0, node1, node2;
+			double dTriangleArea;
 
-            // Loop over all sub-triangles of this Overlap Face
-            for (int k = 0; k < nOverlapTriangles; k++) {
-                if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-                {
-                    node0 = nodesOverlap[faceOverlap[0]];
-                    node1 = nodesOverlap[faceOverlap[1]];
-                    node2 = nodesOverlap[faceOverlap[2]];
-                }
-                else // decompose polygon in triangles around the center
-                {
-                    node0 = center;
-                    node1 = nodesOverlap[faceOverlap[k]];
-                    int k1 = (k + 1) % nbEdges;
-                    node2 = nodesOverlap[faceOverlap[k1]];
-	            }
-                dTriangleArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+			// Loop over all sub-triangles of this Overlap Face
+			for (int k = 0; k < nOverlapTriangles; k++) {
+				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+						{
+					node0 = nodesOverlap[faceOverlap[0]];
+					node1 = nodesOverlap[faceOverlap[1]];
+					node2 = nodesOverlap[faceOverlap[2]];
+				} else // decompose polygon in triangles around the center
+				{
+					node0 = center;
+					node1 = nodesOverlap[faceOverlap[k]];
+					int k1 = (k + 1) % nbEdges;
+					node2 = nodesOverlap[faceOverlap[k1]];
+				}
+				dTriangleArea = CalculateTriangleAreaQuadratureMethod(node0,
+						node1, node2);
 				// Coordinates of quadrature Node
 				for (int l = 0; l < TriQuadraturePoints; l++) {
 					Node nodeQuadrature;
@@ -1275,7 +1275,7 @@ void LinearRemapGLLtoGLL_Pointwise(
 		// Quantities from the First Mesh
 		const Face & faceFirst = meshInput.faces[ixFirst];
 
-		const NodeVector & nodesFirst = meshInput.nodes;
+		const NodeVector &nodesFirst = meshInput.nodes;
 
 		// Number of overlapping Faces and triangles
 		int nOverlapFaces = nAllOverlapFaces[ixFirst];
@@ -1284,52 +1284,55 @@ void LinearRemapGLLtoGLL_Pointwise(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector & nodesOverlap = meshOverlap.nodes;
+			const NodeVector &nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector & nodesSecond = meshOutput.nodes;
+			const NodeVector &nodesSecond = meshOutput.nodes;
 
-			const Face & faceSecond = meshOutput.faces[ixSecond];
+			const Face &faceSecond = meshOutput.faces[ixSecond];
 			int nbEdges = faceOverlap.edges.size();
-            int nOverlapTriangles = 1;
-            Node center; // not used if nbEdges == 3
-            if (nbEdges > 3) { // decompose from center in this case
-                nOverlapTriangles = nbEdges;
-                for (int k = 0; k < nbEdges; k++) {
-                    const Node &node = nodesOverlap[faceOverlap[k]];
-                    center = center + node;
-                }
-                center = center / nbEdges;
-                double magni = sqrt(
-                        center.x * center.x + center.y * center.y
-                                + center.z * center.z);
-                center = center / magni; // project back on sphere of radius 1
-            }
+			int nOverlapTriangles = 1;
+			Node center; // not used if nbEdges == 3
+			if (nbEdges > 3)
+			{ // decompose from center in this case
+				nOverlapTriangles = nbEdges;
+				for (int k = 0; k < nbEdges; k++)
+				{
+					const Node &node = nodesOverlap[faceOverlap[k]];
+					center = center + node;
+				}
+				center = center / nbEdges;
+				double magni = sqrt(
+						center.x * center.x + center.y * center.y
+								+ center.z * center.z);
+				center = center / magni; // project back on sphere of radius 1
+			}
 
-            Node node0, node1, node2;
-            double dTriArea;
+			Node node0, node1, node2;
+			double dTriArea;
 
 			// Loop over all sub-triangles of this Overlap Face
-			for (int j = 0; j < nOverlapTriangles; j++) {
-
-			    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-                {
-                    node0 = nodesOverlap[faceOverlap[0]];
-                    node1 = nodesOverlap[faceOverlap[1]];
-                    node2 = nodesOverlap[faceOverlap[2]];
-                }
-                else // decompose polygon in triangles around the center
-                {
-                    node0 = center;
-                    node1 = nodesOverlap[faceOverlap[j]];
-                    int j1 = (j + 1) % nbEdges;
-                    node2 = nodesOverlap[faceOverlap[j1]];
-                }
-			    dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+			for (int j = 0; j < nOverlapTriangles; j++)
+			{
+				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+				{
+					node0 = nodesOverlap[faceOverlap[0]];
+					node1 = nodesOverlap[faceOverlap[1]];
+					node2 = nodesOverlap[faceOverlap[2]];
+				}
+				else // decompose polygon in triangles around the center
+				{
+					node0 = center;
+					node1 = nodesOverlap[faceOverlap[j]];
+					int j1 = (j + 1) % nbEdges;
+					node2 = nodesOverlap[faceOverlap[j1]];
+				}
+				dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1,
+						node2);
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 
 					// Get the nodal location of this point
@@ -1894,21 +1897,21 @@ void LinearRemapGLLtoGLL_Integrated(
 
 	int ixTotal = 0;
 
-	std::set< std::pair<int, int> > setFound;
+	std::set<std::pair<int, int> > setFound;
 
-    // Loop over all input Faces
+	// Loop over all input Faces
 
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
 		// Output every 100 elements
 		if (ixFirst % 1000 == 0) {
-                  Announce("Element %i/%i", ixFirst,meshInput.faces.size());
+			Announce("Element %i/%i", ixFirst, meshInput.faces.size());
 		}
 
 		// Quantities from the First Mesh
-		const Face & faceFirst = meshInput.faces[ixFirst];
+		const Face &faceFirst = meshInput.faces[ixFirst];
 
-		const NodeVector & nodesFirst = meshInput.nodes;
+		const NodeVector &nodesFirst = meshInput.nodes;
 
 		// Number of overlapping Faces and triangles
 		int nOverlapFaces = nAllOverlapFaces[ixFirst];
@@ -1917,52 +1920,52 @@ void LinearRemapGLLtoGLL_Integrated(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector & nodesOverlap = meshOverlap.nodes;
+			const NodeVector &nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector & nodesSecond = meshOutput.nodes;
+			const NodeVector &nodesSecond = meshOutput.nodes;
 
-			const Face & faceSecond = meshOutput.faces[ixSecond];
+			const Face &faceSecond = meshOutput.faces[ixSecond];
 
 			int nbEdges = faceOverlap.edges.size();
-            int nOverlapTriangles = 1;
-            Node center; // not used if nbEdges == 3
-            if (nbEdges > 3) { // decompose from center in this case
-                nOverlapTriangles = nbEdges;
-                for (int k = 0; k < nbEdges; k++) {
-                    const Node &node = nodesOverlap[faceOverlap[k]];
-                    center = center + node;
-                }
-                center = center / nbEdges;
-                double magni = sqrt(
-                        center.x * center.x + center.y * center.y
-                                + center.z * center.z);
-                center = center / magni; // project back on sphere of radius 1
-            }
+			int nOverlapTriangles = 1;
+			Node center; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from center in this case
+				nOverlapTriangles = nbEdges;
+				for (int k = 0; k < nbEdges; k++) {
+					const Node &node = nodesOverlap[faceOverlap[k]];
+					center = center + node;
+				}
+				center = center / nbEdges;
+				double magni = sqrt(
+						center.x * center.x + center.y * center.y
+								+ center.z * center.z);
+				center = center / magni; // project back on sphere of radius 1
+			}
 
-            Node node0, node1, node2;
-            double dTriArea;
+			Node node0, node1, node2;
+			double dTriArea;
 
-            // Loop over all sub-triangles of this Overlap Face
-            for (int k = 0; k < nOverlapTriangles; k++) {
-                if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-                {
-                    node0 = nodesOverlap[faceOverlap[0]];
-                    node1 = nodesOverlap[faceOverlap[1]];
-                    node2 = nodesOverlap[faceOverlap[2]];
-                }
-                else // decompose polygon in triangles around the center
-                {
-                    node0 = center;
-                    node1 = nodesOverlap[faceOverlap[k]];
-                    int k1 = (k + 1) % nbEdges;
-                    node2 = nodesOverlap[faceOverlap[k1]];
-                }
-                dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1, node2);
+			// Loop over all sub-triangles of this Overlap Face
+			for (int k = 0; k < nOverlapTriangles; k++) {
+				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+				{
+					node0 = nodesOverlap[faceOverlap[0]];
+					node1 = nodesOverlap[faceOverlap[1]];
+					node2 = nodesOverlap[faceOverlap[2]];
+				} else // decompose polygon in triangles around the center
+				{
+					node0 = center;
+					node1 = nodesOverlap[faceOverlap[k]];
+					int k1 = (k + 1) % nbEdges;
+					node2 = nodesOverlap[faceOverlap[k1]];
+				}
+				dTriArea = CalculateTriangleAreaQuadratureMethod(node0, node1,
+						node2);
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -806,6 +806,16 @@ void LinearRemapSE4(
 	// Current Overlap Face
 	int ixOverlap = 0;
 
+	// generic triangle used for area computation, for triangles around the center of overlap face;
+	// used for overlap faces with more than 4 edges;
+	// nodes array will be set for each triangle;
+	// these triangles are not part of the mesh structure, they are just temporary during
+	//   aforementioned decomposition.
+	Face faceTri( 3 );
+	NodeVector nodes( 3 );
+    faceTri.SetNode( 0, 0 );
+    faceTri.SetNode( 1, 1 );
+    faceTri.SetNode( 2, 2 );
 	// Loop over all input Faces
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
@@ -822,7 +832,6 @@ void LinearRemapSE4(
 
 		// Number of overlapping Faces and triangles
 		int nOverlapFaces = 0;
-		int nTotalOverlapTriangles = 0;
 
 		// Determine how many overlap Faces and triangles are present
 		int ixOverlapTemp = ixOverlap;
@@ -833,9 +842,7 @@ void LinearRemapSE4(
 			if (meshOverlap.vecSourceFaceIx[ixOverlapTemp] != ixFirst) {
 				break;
 			}
-
 			nOverlapFaces++;
-			nTotalOverlapTriangles += faceOverlap.edges.size() - 2;
 		}
 
 		// No overlaps
@@ -849,59 +856,46 @@ void LinearRemapSE4(
 		// Find the local remap coefficients
 		for (int j = 0; j < nOverlapFaces; j++) {
 			const Face & faceOverlap = meshOverlap.faces[ixOverlap + j];
-#define USE_CENTER_POLYGON
-
-#ifdef  USE_CENTER_POLYGON
-            int nOverlapTriangles = faceOverlap.edges.size();
-            Node center = nodesOverlap[faceOverlap[0]];
-            for (int i=1; i< nOverlapTriangles; i++)
-            {
-                const Node& node = nodesOverlap[faceOverlap[i]];
-                center = center + node;
+			int nbEdges = faceOverlap.edges.size();
+			int nOverlapTriangles = 1;
+			Node center; // not used if nbEdges == 3
+            if (nbEdges > 3) { // decompose from center in this case
+                nOverlapTriangles = nbEdges;
+                for (int k = 0; k < nbEdges; k++) {
+                    const Node &node = nodesOverlap[faceOverlap[k]];
+                    center = center + node;
+                }
+                center = center / nbEdges;
+                double magni = sqrt(
+                        center.x * center.x + center.y * center.y
+                                + center.z * center.z);
+                center = center / magni; // project back on sphere of radius 1
             }
-            center = center/nOverlapTriangles;
-            double magni = sqrt( center.x * center.x + center.y * center.y +
-                    center.z * center.z );
-            center = center/magni; // project back on sphere
 
-#else
-            int nOverlapTriangles = faceOverlap.edges.size() - 2;
-#endif
+            Node node0, node1, node2;
+            double dTriangleArea;
 
-			// Loop over all sub-triangles of this Overlap Face
-			for (int k = 0; k < nOverlapTriangles; k++) {
-#ifdef  USE_CENTER_POLYGON
-			    Face faceTri( 3 );
-                NodeVector nodes( 3 );
-                nodes[0] = center;
-                nodes[1] = nodesOverlap[faceOverlap[k]];
-                int k1 = (k+1)%nOverlapTriangles;
-                nodes[2] = nodesOverlap[faceOverlap[k1]];
-                faceTri.SetNode( 0, 0 );
-                faceTri.SetNode( 1, 1 );
-                faceTri.SetNode( 2, 2 );
-                // this should be simplified; we are forming these arrays just to compute area of a triangle
-                // face palm :(
-                double dTriangleArea = CalculateFaceArea( faceTri, nodes );
-                const Node& node0 = nodes[0];
-                const Node& node1 = nodes[1];
-                const Node& node2 = nodes[2];
-#else
+            // Loop over all sub-triangles of this Overlap Face
+            for (int k = 0; k < nOverlapTriangles; k++) {
+                if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+                {
+                    node0 = nodesOverlap[faceOverlap[0]];
+                    node1 = nodesOverlap[faceOverlap[1]];
+                    node2 = nodesOverlap[faceOverlap[2]];
+                    dTriangleArea = CalculateFaceArea(faceOverlap, nodesOverlap);
+                }
+                else // decompose polygon in triangles around the center
+                {
+                    node0 = center;
+                    node1 = nodesOverlap[faceOverlap[k]];
+                    int k1 = (k + 1) % nbEdges;
+                    node2 = nodesOverlap[faceOverlap[k1]];
+                    nodes[0] = center;
+                    nodes[1] = node1;
+                    nodes[2] = node2;
+                    dTriangleArea = CalculateFaceArea(faceTri, nodes);
+	            }
 
-				// Cornerpoints of triangle
-				const Node & node0 = nodesOverlap[faceOverlap[0]];
-				const Node & node1 = nodesOverlap[faceOverlap[k+1]];
-				const Node & node2 = nodesOverlap[faceOverlap[k+2]];
-
-				// Calculate the area of the modified Face
-				Face faceTri(3);
-				faceTri.SetNode(0, faceOverlap[0]);
-				faceTri.SetNode(1, faceOverlap[k+1]);
-				faceTri.SetNode(2, faceOverlap[k+2]);
-
-				double dTriangleArea =
-					CalculateFaceArea(faceTri, nodesOverlap);
-#endif
 				// Coordinates of quadrature Node
 				for (int l = 0; l < TriQuadraturePoints; l++) {
 					Node nodeQuadrature;
@@ -1256,6 +1250,17 @@ void LinearRemapGLLtoGLL_Pointwise(
 	// Number of overlap Faces per source Face
 	DataArray1D<int> nAllOverlapFaces(meshInput.faces.size());
 
+	// generic triangle used for area computation, for triangles around the center of overlap face;
+    // used for overlap faces with more than 4 edges;
+    // nodes array will be set for each triangle;
+    // these triangles are not part of the mesh structure, they are just temporary during
+    //   aforementioned decomposition.
+    Face faceTri( 3 );
+    NodeVector nodes( 3 );
+    faceTri.SetNode( 0, 0 );
+    faceTri.SetNode( 1, 1 );
+    faceTri.SetNode( 2, 2 );
+
 	int ixOverlap = 0;
 
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
@@ -1309,31 +1314,52 @@ void LinearRemapGLLtoGLL_Pointwise(
 
 			const NodeVector & nodesOverlap = meshOverlap.nodes;
 
-			int nOverlapTriangles = faceOverlap.edges.size() - 2;
-
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
 			const NodeVector & nodesSecond = meshOutput.nodes;
 
 			const Face & faceSecond = meshOutput.faces[ixSecond];
+			int nbEdges = faceOverlap.edges.size();
+            int nOverlapTriangles = 1;
+            Node center; // not used if nbEdges == 3
+            if (nbEdges > 3) { // decompose from center in this case
+                nOverlapTriangles = nbEdges;
+                for (int k = 0; k < nbEdges; k++) {
+                    const Node &node = nodesOverlap[faceOverlap[k]];
+                    center = center + node;
+                }
+                center = center / nbEdges;
+                double magni = sqrt(
+                        center.x * center.x + center.y * center.y
+                                + center.z * center.z);
+                center = center / magni; // project back on sphere of radius 1
+            }
+
+            Node node0, node1, node2;
+            double dTriArea;
 
 			// Loop over all sub-triangles of this Overlap Face
 			for (int j = 0; j < nOverlapTriangles; j++) {
 
-				// Cornerpoints of triangle
-				const Node & node0 = nodesOverlap[faceOverlap[0]];
-				const Node & node1 = nodesOverlap[faceOverlap[j+1]];
-				const Node & node2 = nodesOverlap[faceOverlap[j+2]];
-
-				// Calculate the area of the modified Face
-				Face faceTri(3);
-				faceTri.SetNode(0, faceOverlap[0]);
-				faceTri.SetNode(1, faceOverlap[j+1]);
-				faceTri.SetNode(2, faceOverlap[j+2]);
-
-				double dTriArea =
-					CalculateFaceArea(faceTri, nodesOverlap);
+			    if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+                {
+                    node0 = nodesOverlap[faceOverlap[0]];
+                    node1 = nodesOverlap[faceOverlap[1]];
+                    node2 = nodesOverlap[faceOverlap[2]];
+                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
+                }
+                else // decompose polygon in triangles around the center
+                {
+                    node0 = center;
+                    node1 = nodesOverlap[faceOverlap[j]];
+                    int j1 = (j + 1) % nbEdges;
+                    node2 = nodesOverlap[faceOverlap[j1]];
+                    nodes[0] = center;
+                    nodes[1] = node1;
+                    nodes[2] = node2;
+                    dTriArea = CalculateFaceArea(faceTri, nodes);
+                }
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 
@@ -1901,6 +1927,19 @@ void LinearRemapGLLtoGLL_Integrated(
 
 	std::set< std::pair<int, int> > setFound;
 
+	// generic triangle used for area computation, for triangles around the center of overlap face;
+    // used for overlap faces with more than 4 edges;
+    // nodes array will be set for each triangle;
+    // these triangles are not part of the mesh structure, they are just temporary during
+    //   aforementioned decomposition.
+    Face faceTri( 3 );
+    NodeVector nodes( 3 );
+    faceTri.SetNode( 0, 0 );
+    faceTri.SetNode( 1, 1 );
+    faceTri.SetNode( 2, 2 );
+
+    // Loop over all input Faces
+
 	for (int ixFirst = 0; ixFirst < meshInput.faces.size(); ixFirst++) {
 
 		// Output every 100 elements
@@ -1924,8 +1963,6 @@ void LinearRemapGLLtoGLL_Integrated(
 
 			const NodeVector & nodesOverlap = meshOverlap.nodes;
 
-			int nOverlapTriangles = faceOverlap.edges.size() - 2;
-
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
@@ -1933,22 +1970,45 @@ void LinearRemapGLLtoGLL_Integrated(
 
 			const Face & faceSecond = meshOutput.faces[ixSecond];
 
-			// Loop over all sub-triangles of this Overlap Face
-			for (int j = 0; j < nOverlapTriangles; j++) {
+			int nbEdges = faceOverlap.edges.size();
+            int nOverlapTriangles = 1;
+            Node center; // not used if nbEdges == 3
+            if (nbEdges > 3) { // decompose from center in this case
+                nOverlapTriangles = nbEdges;
+                for (int k = 0; k < nbEdges; k++) {
+                    const Node &node = nodesOverlap[faceOverlap[k]];
+                    center = center + node;
+                }
+                center = center / nbEdges;
+                double magni = sqrt(
+                        center.x * center.x + center.y * center.y
+                                + center.z * center.z);
+                center = center / magni; // project back on sphere of radius 1
+            }
 
-				// Cornerpoints of triangle
-				const Node & node0 = nodesOverlap[faceOverlap[0]];
-				const Node & node1 = nodesOverlap[faceOverlap[j+1]];
-				const Node & node2 = nodesOverlap[faceOverlap[j+2]];
+            Node node0, node1, node2;
+            double dTriArea;
 
-				// Calculate the area of the modified Face
-				Face faceTri(3);
-				faceTri.SetNode(0, faceOverlap[0]);
-				faceTri.SetNode(1, faceOverlap[j+1]);
-				faceTri.SetNode(2, faceOverlap[j+2]);
-
-				double dTriArea =
-					CalculateFaceArea(faceTri, nodesOverlap);
+            // Loop over all sub-triangles of this Overlap Face
+            for (int k = 0; k < nOverlapTriangles; k++) {
+                if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
+                {
+                    node0 = nodesOverlap[faceOverlap[0]];
+                    node1 = nodesOverlap[faceOverlap[1]];
+                    node2 = nodesOverlap[faceOverlap[2]];
+                    dTriArea = CalculateFaceArea(faceOverlap, nodesOverlap);
+                }
+                else // decompose polygon in triangles around the center
+                {
+                    node0 = center;
+                    node1 = nodesOverlap[faceOverlap[k]];
+                    int k1 = (k + 1) % nbEdges;
+                    node2 = nodesOverlap[faceOverlap[k1]];
+                    nodes[0] = center;
+                    nodes[1] = node1;
+                    nodes[2] = node2;
+                    dTriArea = CalculateFaceArea(faceTri, nodes);
+                }
 
 				for (int k = 0; k < triquadrule.GetPoints(); k++) {
 

--- a/src/LinearRemapSE0.cpp
+++ b/src/LinearRemapSE0.cpp
@@ -845,21 +845,21 @@ void LinearRemapSE4(
 
 		// Find the local remap coefficients
 		for (int j = 0; j < nOverlapFaces; j++) {
-			const Face &faceOverlap = meshOverlap.faces[ixOverlap + j];
+			const Face & faceOverlap = meshOverlap.faces[ixOverlap + j];
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
-			Node center; // not used if nbEdges == 3
-			if (nbEdges > 3) { // decompose from center in this case
+			Node nodeCenter; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from nodeCenter in this case
 				nOverlapTriangles = nbEdges;
 				for (int k = 0; k < nbEdges; k++) {
 					const Node &node = nodesOverlap[faceOverlap[k]];
-					center = center + node;
+					nodeCenter = nodeCenter + node;
 				}
-				center = center / nbEdges;
-				double magni = sqrt(
-						center.x * center.x + center.y * center.y
-								+ center.z * center.z);
-				center = center / magni; // project back on sphere of radius 1
+				nodeCenter = nodeCenter / nbEdges;
+				double dMagni = sqrt(
+						nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+								+ nodeCenter.z * nodeCenter.z);
+				nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 			}
 
 			Node node0, node1, node2;
@@ -867,15 +867,13 @@ void LinearRemapSE4(
 
 			// Loop over all sub-triangles of this Overlap Face
 			for (int k = 0; k < nOverlapTriangles; k++) {
-				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-				{
+				if (nbEdges == 3) { // will come here only once, nOverlapTriangles == 1 in this case
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
 				}
-				else // decompose polygon in triangles around the center
-				{
-					node0 = center;
+				else { // decompose polygon in triangles around the nodeCenter
+					node0 = nodeCenter;
 					node1 = nodesOverlap[faceOverlap[k]];
 					int k1 = (k + 1) % nbEdges;
 					node2 = nodesOverlap[faceOverlap[k1]];
@@ -1285,49 +1283,44 @@ void LinearRemapGLLtoGLL_Pointwise(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector &nodesOverlap = meshOverlap.nodes;
+			const NodeVector & nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector &nodesSecond = meshOutput.nodes;
+			const NodeVector & nodesSecond = meshOutput.nodes;
 
-			const Face &faceSecond = meshOutput.faces[ixSecond];
+			const Face & faceSecond = meshOutput.faces[ixSecond];
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
-			Node center; // not used if nbEdges == 3
-			if (nbEdges > 3)
-			{ // decompose from center in this case
+			Node nodeCenter; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from nodeCenter in this case
 				nOverlapTriangles = nbEdges;
-				for (int k = 0; k < nbEdges; k++)
-				{
+				for (int k = 0; k < nbEdges; k++) {
 					const Node &node = nodesOverlap[faceOverlap[k]];
-					center = center + node;
+					nodeCenter = nodeCenter + node;
 				}
-				center = center / nbEdges;
-				double magni = sqrt(
-						center.x * center.x + center.y * center.y
-								+ center.z * center.z);
-				center = center / magni; // project back on sphere of radius 1
+				nodeCenter = nodeCenter / nbEdges;
+				double dMagni = sqrt(
+						nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+								+ nodeCenter.z * nodeCenter.z);
+				nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 			}
 
 			Node node0, node1, node2;
 			double dTriArea;
 
 			// Loop over all sub-triangles of this Overlap Face
-			for (int j = 0; j < nOverlapTriangles; j++)
-			{
-				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-				{
+			for (int j = 0; j < nOverlapTriangles; j++) {
+				if (nbEdges == 3) { // will come here only once, nOverlapTriangles == 1 in this case
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
 				}
-				else // decompose polygon in triangles around the center
-				{
-					node0 = center;
+				else { // decompose polygon in triangles around the nodeCenter
+					node0 = nodeCenter;
 					node1 = nodesOverlap[faceOverlap[j]];
 					int j1 = (j + 1) % nbEdges;
 					node2 = nodesOverlap[faceOverlap[j1]];
@@ -1921,31 +1914,31 @@ void LinearRemapGLLtoGLL_Integrated(
 		for (int i = 0; i < nOverlapFaces; i++) {
 
 			// Quantities from the overlap Mesh
-			const Face &faceOverlap = meshOverlap.faces[ixOverlap + i];
+			const Face & faceOverlap = meshOverlap.faces[ixOverlap + i];
 
-			const NodeVector &nodesOverlap = meshOverlap.nodes;
+			const NodeVector & nodesOverlap = meshOverlap.nodes;
 
 			// Quantities from the Second Mesh
 			int ixSecond = meshOverlap.vecTargetFaceIx[ixOverlap + i];
 
-			const NodeVector &nodesSecond = meshOutput.nodes;
+			const NodeVector & nodesSecond = meshOutput.nodes;
 
-			const Face &faceSecond = meshOutput.faces[ixSecond];
+			const Face & faceSecond = meshOutput.faces[ixSecond];
 
 			int nbEdges = faceOverlap.edges.size();
 			int nOverlapTriangles = 1;
-			Node center; // not used if nbEdges == 3
-			if (nbEdges > 3) { // decompose from center in this case
+			Node nodeCenter; // not used if nbEdges == 3
+			if (nbEdges > 3) { // decompose from nodeCenter in this case
 				nOverlapTriangles = nbEdges;
 				for (int k = 0; k < nbEdges; k++) {
 					const Node &node = nodesOverlap[faceOverlap[k]];
-					center = center + node;
+					nodeCenter = nodeCenter + node;
 				}
-				center = center / nbEdges;
-				double magni = sqrt(
-						center.x * center.x + center.y * center.y
-								+ center.z * center.z);
-				center = center / magni; // project back on sphere of radius 1
+				nodeCenter = nodeCenter / nbEdges;
+				double dMagni = sqrt(
+						nodeCenter.x * nodeCenter.x + nodeCenter.y * nodeCenter.y
+								+ nodeCenter.z * nodeCenter.z);
+				nodeCenter = nodeCenter / dMagni; // project back on sphere of radius 1
 			}
 
 			Node node0, node1, node2;
@@ -1953,14 +1946,13 @@ void LinearRemapGLLtoGLL_Integrated(
 
 			// Loop over all sub-triangles of this Overlap Face
 			for (int k = 0; k < nOverlapTriangles; k++) {
-				if (nbEdges == 3) // will come here only once, nOverlapTriangles == 1 in this case
-				{
+				if (nbEdges == 3) { // will come here only once, nOverlapTriangles == 1 in this case
 					node0 = nodesOverlap[faceOverlap[0]];
 					node1 = nodesOverlap[faceOverlap[1]];
 					node2 = nodesOverlap[faceOverlap[2]];
-				} else // decompose polygon in triangles around the center
-				{
-					node0 = center;
+				}
+				else { // decompose polygon in triangles around the nodeCenter
+					node0 = nodeCenter;
 					node1 = nodesOverlap[faceOverlap[k]];
 					int k1 = (k + 1) % nbEdges;
 					node2 = nodesOverlap[faceOverlap[k1]];


### PR DESCRIPTION
Overlap polygons with at least 4 edges are decomposed in triangles from the center of mass.
do not decompose if overlap face is a triangle
Original decomposition uses lower number of triangles but this gives better shapes in general, and it does
not depend on the starting node of the polygon;

also, introduce a new function that computes area of a triangle from 3 nodes, by Gauss integration;
It simplifies the code more