### PR TITLE
GNU and Clang are picky with this particular warning 

### DIFF
--- a/src/Subscript.h
+++ b/src/Subscript.h
@@ -30,7 +30,7 @@
 template <typename T, size_t size>
 struct index_array
 {
-	T ix_[size];
+	T ix_[size+1];
 
 #if defined(__INTEL_COMPILER)
 	inline T& operator[](int i) {


### PR DESCRIPTION
This often shows up in downstream applications (e.g., MOAB).

A sample warning message is shown below. This can be replicated when instantiating the operator [] of
DataArray2D and DataArray3D.
```
Subscript.h:33:8: warning: zero size arrays are an extension [-Wzero-length-array]
        T ix_[size];
              ^~~~
Subscript.h:69:30: note: in instantiation of template class 'index_array<long, 0>' requested here
        index_array<size_type, Dim> indices_;
                                    ^
DataArray3D.h:399:35: note: in instantiation of template class 'Subscript<DataArray3D<int>, 3, 3>' requested here
                Subscript<DataArray3D<T>, 3, 3> s(*this);
```
The fix, although trivial removes the warning (since it will always have a minimum size of 1). And from what I checked, there have been no regressions with the new changes.