### PR TITLE
Use .data() to get pointer to std::vector

### DIFF
--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -556,8 +556,8 @@ void Mesh::Write(
 				_EXCEPTION1("Error creating variable \"%s\"", szAttribName);
 			}
 
-			varAttrib->set_cur((long)0);
-			varAttrib->put(&(dAttrib[0]), vecBlockSizeFaces[n]);
+			varAttrib->set_cur((long)0, (long)0);
+			varAttrib->put(&(dAttrib[0]), vecBlockSizeFaces[n], 1);
 		}
 	}
 


### PR DESCRIPTION
When using the jll binaries, we noticed that the `attrib1` was set to a strange result (`9.969209968386869e36` or `0x479e000000000000` in hex): according to the code however, it looks like it is supposed be `1.0`.

I think the problem is caused by this line: `&(dAttrib[0])` may not give a pointer to the array, but just a pointer to a location that has the same value as `dAttrib[0]` (I may be wrong: my C++ knowledge is pretty limited). From what I understand, I think the correct approach is to use [`.data()`](https://www.cplusplus.com/reference/vector/vector/data/).

cc: @jakebolewski (who knows more C++ than I do)

