### PR TITLE
skip degenerated triangles for volumetric option

### DIFF
--- a/src/FiniteVolumeTools.cpp
+++ b/src/FiniteVolumeTools.cpp
@@ -1054,6 +1054,8 @@ void BuildIntegrationArray(
 		const NodeVector &nodesOverlap = meshOverlap.nodes;
 
 		int nbEdges = faceOverlap.edges.size();
+		if (nbEdges < 3)
+		    continue; // skip / ignore degenerated triangles
 		int nOverlapTriangles = 1;
 		Node nodeCenter; // not used if nbEdges == 3
 		if (nbEdges > 3) { // decompose from center in this case


### PR DESCRIPTION
use case:
`GenerateOfflineMap --in_mesh icotri15.g --out_mesh outCSMesh10.g --ov_mesh ov_fvcs.g --out_type cgll --out_np 2 --out_map vol.nc --volumetric`

this code crashes on master because some overlap faces are degenerate
On this branch, overlap faces with less than 3 edges are skipped; not sure why "volumetric" option triggers this behavior; so this PR fixes the symptom, but the cause of this is could be deeper. 