### PR TITLE
Caught by clang compiler on OSX

### DIFF
--- a/src/Announce.cpp
+++ b/src/Announce.cpp
@@ -135,7 +135,7 @@ void AnnounceStartBlock(
 	char szBuffer[AnnouncementBufferSize];
 	va_list arguments;
 	va_start(arguments, szText);
-	vsprintf(szBuffer, szText, arguments);
+	vsnprintf(szBuffer, AnnouncementBufferSize, szText, arguments);
 	va_end(arguments);
 
 	// Output with proper indentation
@@ -195,7 +195,7 @@ void AnnounceEndBlock(
 
 		va_list arguments;
 		va_start(arguments, szText);
-		vsprintf(szBuffer, szText, arguments);
+		vsnprintf(szBuffer, AnnouncementBufferSize, szText, arguments);
 		va_end(arguments);
 
 		if (s_fBlockFlag) {
@@ -266,7 +266,7 @@ void Announce(const char * szText, ...) {
 	va_start(arguments, szText);
 
 	// Write to string
-	vsprintf(szBuffer, szText, arguments);
+	vsnprintf(szBuffer, AnnouncementBufferSize, szText, arguments);
 
 	// Cleans up the argument list
 	va_end(arguments);
@@ -328,7 +328,7 @@ void Announce(
 	va_start(arguments, szText);
 
 	// Write to string
-	vsprintf(szBuffer, szText, arguments);
+	vsnprintf(szBuffer, AnnouncementBufferSize, szText, arguments);
 
 	// Cleans up the argument list
 	va_end(arguments);

--- a/src/CoarsenRectilinearData.cpp
+++ b/src/CoarsenRectilinearData.cpp
@@ -694,7 +694,7 @@ try {
 	// Remap
 	for (int i = 0; i < nData; i++) {
 		char szBuffer[256];
-		sprintf(szBuffer, "Remapping data instance %i", i);
+		snprintf(szBuffer, 256, "Remapping data instance %i", i);
 		AnnounceStartBlock(szBuffer);
 
 		DataArray1D<long> lDataIx(varData->num_dims());

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -79,6 +79,7 @@ class Exception {
 		///		Maximum buffer size for exception strings.
 		///	</summary>
 		static const int ExceptionBufferSize = 1024;
+		static const int ExceptionReturnBufferSize = 128;
 
 	public:
 		///	<summary>
@@ -113,7 +114,7 @@ class Exception {
 			va_start(arguments, szText);
 
 			// Write to string
-			vsprintf(szBuffer, szText, arguments);
+			vsnprintf(szBuffer, ExceptionBufferSize, szText, arguments);
 
 			m_strText = szBuffer;
 
@@ -128,17 +129,17 @@ class Exception {
 		std::string ToString() const {
 			std::string strReturn;
 
-			char szBuffer[128];
+			char szBuffer[ExceptionReturnBufferSize];
 
 			// Preamble
-			sprintf(szBuffer, "EXCEPTION (");
+			snprintf(szBuffer, ExceptionReturnBufferSize, "EXCEPTION (");
 			strReturn.append(szBuffer);
 
 			// File name
 			strReturn.append(m_strFile);
 
 			// Line number
-			sprintf(szBuffer, ", Line %u) ", m_uiLine);
+			snprintf(szBuffer, ExceptionReturnBufferSize, ", Line %u) ", m_uiLine);
 			strReturn.append(szBuffer);
 
 			// Text

--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -406,7 +406,7 @@ void Mesh::Write(
 		strftime(szTime, sizeof(szTime), "%X", timestruct);
 
 		char szTitle[128];
-		sprintf(szTitle, "tempest(%s) %s: %s", strFile.c_str(), szDate, szTime);
+		snprintf(szTitle, 128, "tempest(%s) %s: %s", strFile.c_str(), szDate, szTime);
 		ncOut.add_att("title", szTitle);
 
 		// Time_whole (unused)
@@ -467,7 +467,7 @@ void Mesh::Write(
 
 	char szBuffer[ParamLenString];
 	for (int n = 0; n < vecBlockSizes.size(); n++) {
-		sprintf(szBuffer, "num_el_in_blk%i", n+1);
+		snprintf(szBuffer, ParamLenString, "num_el_in_blk%i", n+1);
 		vecElementBlockDim[n] =
 			ncOut.add_dim(szBuffer, vecBlockSizeFaces[n]);
 
@@ -475,7 +475,7 @@ void Mesh::Write(
 			_EXCEPTION1("Error creating dimension \"%s\"", szBuffer);
 		}
 
-		sprintf(szBuffer, "num_nod_per_el%i", n+1);
+		snprintf(szBuffer, ParamLenString, "num_nod_per_el%i", n+1);
 		vecNodesPerElementDim[n] =
 			ncOut.add_dim(szBuffer, vecBlockSizes[n]);
 
@@ -483,7 +483,7 @@ void Mesh::Write(
 			_EXCEPTION1("Error creating dimension \"%s\"", szBuffer);
 		}
 
-		sprintf(szBuffer, "num_att_in_blk%i", n+1);
+		snprintf(szBuffer, ParamLenString, "num_att_in_blk%i", n+1);
 		vecAttBlockDim[n] =
 			ncOut.add_dim(szBuffer, 1);
 
@@ -545,7 +545,7 @@ void Mesh::Write(
 			}
 
 			char szAttribName[ParamLenString];
-			sprintf(szAttribName, "attrib%i", n+1);
+			snprintf(szAttribName, ParamLenString, "attrib%i", n+1);
 
 			NcVar * varAttrib =
 				ncOut.add_var(
@@ -610,7 +610,7 @@ void Mesh::Write(
 			vecEdgeType[n].Allocate(vecBlockSizeFaces[n], vecBlockSizes[n]);
 	
 			char szConnectVarName[ParamLenString];
-			sprintf(szConnectVarName, "connect%i", n+1);
+			snprintf(szConnectVarName, ParamLenString, "connect%i", n+1);
 			vecConnectVar[n] =
 				ncOut.add_var(
 					szConnectVarName, ncInt,
@@ -623,11 +623,11 @@ void Mesh::Write(
 			}
 
 			char szConnectAttrib[ParamLenString];
-			sprintf(szConnectAttrib, "SHELL%i", vecBlockSizes[n]);
+			snprintf(szConnectAttrib, ParamLenString, "SHELL%i", vecBlockSizes[n]);
 			vecConnectVar[n]->add_att("elem_type", szConnectAttrib);
 
 			char szGlobalIdVarName[ParamLenString];
-			sprintf(szGlobalIdVarName, "global_id%i", n+1);
+			snprintf(szGlobalIdVarName, ParamLenString, "global_id%i", n+1);
 			vecGlobalIdVar[n] = 
 				ncOut.add_var(
 					szGlobalIdVarName, ncInt,
@@ -639,7 +639,7 @@ void Mesh::Write(
 			}
 
 			char szEdgeTypeVarName[ParamLenString];
-			sprintf(szEdgeTypeVarName, "edge_type%i", n+1);
+			snprintf(szEdgeTypeVarName, ParamLenString, "edge_type%i", n+1);
 			vecEdgeTypeVar[n] =
 				ncOut.add_var(
 					szEdgeTypeVarName, ncInt,
@@ -655,7 +655,7 @@ void Mesh::Write(
 				vecFaceParentA[n].Allocate(vecBlockSizeFaces[n]);
 
 				char szParentAVarName[ParamLenString];
-				sprintf(szParentAVarName, "el_parent_a%i", n+1);
+				snprintf(szParentAVarName, ParamLenString, "el_parent_a%i", n+1);
 				vecFaceParentAVar[n] =
 					ncOut.add_var(
 						szParentAVarName, ncInt,
@@ -671,7 +671,7 @@ void Mesh::Write(
 				vecFaceParentB[n].Allocate(vecBlockSizeFaces[n]);
 
 				char szParentBVarName[ParamLenString];
-				sprintf(szParentBVarName, "el_parent_b%i", n+1);
+				snprintf(szParentBVarName, ParamLenString, "el_parent_b%i", n+1);
 				vecFaceParentBVar[n] =
 					ncOut.add_var(
 						szParentBVarName, ncInt,
@@ -1367,7 +1367,7 @@ void Mesh::Read(const std::string & strFile) {
 
 			// Determine number of nodes per element in this block
 			char szNodesPerElement[ParamLenString];
-			sprintf(szNodesPerElement, "num_nod_per_el%i", n+1);
+			snprintf(szNodesPerElement, ParamLenString, "num_nod_per_el%i", n+1);
 			NcDim * dimNodesPerElement = ncFile.get_dim(szNodesPerElement);
 			if (dimNodesPerElement == NULL) {
 				_EXCEPTION2("Exodus Grid file \"%s\" is missing dimension "
@@ -1377,7 +1377,7 @@ void Mesh::Read(const std::string & strFile) {
 
 			// Number of elements in block
 			char szElementsInBlock[ParamLenString];
-			sprintf(szElementsInBlock, "num_el_in_blk%i", n+1);
+			snprintf(szElementsInBlock, ParamLenString, "num_el_in_blk%i", n+1);
 
 			NcDim * dimBlockElements = ncFile.get_dim(szElementsInBlock);
 			if (dimBlockElements == NULL) {
@@ -1396,7 +1396,7 @@ void Mesh::Read(const std::string & strFile) {
 
 			// Load in nodes for all elements in this block
 			char szConnect[ParamLenString];
-			sprintf(szConnect, "connect%i", n+1);
+			snprintf(szConnect, ParamLenString, "connect%i", n+1);
 
 			NcVar * varConnect = ncFile.get_var(szConnect);
 			if (varConnect == NULL) {
@@ -1419,7 +1419,7 @@ void Mesh::Read(const std::string & strFile) {
 			// Load in global id for all elements in this block
 			} else {
 				char szGlobalId[ParamLenString];
-				sprintf(szGlobalId, "global_id%i", n+1);
+				snprintf(szGlobalId, ParamLenString, "global_id%i", n+1);
 
 				NcVar * varGlobalId = ncFile.get_var(szGlobalId);
 				if (varGlobalId == NULL) {
@@ -1436,9 +1436,9 @@ void Mesh::Read(const std::string & strFile) {
 			// Load in edge type for all elements in this block
 			char szEdgeType[ParamLenString];
 			if (flVersion == 4.98f) {
-				sprintf(szEdgeType, "edge_type");
+				snprintf(szEdgeType, ParamLenString, "edge_type");
 			} else {
-				sprintf(szEdgeType, "edge_type%i", n+1);
+				snprintf(szEdgeType, ParamLenString, "edge_type%i", n+1);
 			}
 
 			NcVar * varEdgeType = ncFile.get_var(szEdgeType);
@@ -1453,9 +1453,9 @@ void Mesh::Read(const std::string & strFile) {
 			// Load in parent from A grid for all elements in this block
 			char szParentA[ParamLenString];
 			if (flVersion == 4.98f) {
-				sprintf(szParentA, "face_source_1");
+				snprintf(szParentA, ParamLenString, "face_source_1");
 			} else {
-				sprintf(szParentA, "el_parent_a%i", n+1);
+				snprintf(szParentA, ParamLenString, "el_parent_a%i", n+1);
 			}
 
 			NcVar * varParentA = ncFile.get_var(szParentA);
@@ -1477,9 +1477,9 @@ void Mesh::Read(const std::string & strFile) {
 			// Load in parent from A grid for all elements in this block
 			char szParentB[ParamLenString];
 			if (flVersion == 4.98f) {
-				sprintf(szParentB, "face_source_2");
+				snprintf(szParentB, ParamLenString, "face_source_2");
 			} else {
-				sprintf(szParentB, "el_parent_b%i", n+1);
+				snprintf(szParentB, ParamLenString, "el_parent_b%i", n+1);
 			}
 
 			NcVar * varParentB = ncFile.get_var(szParentB);
@@ -2711,7 +2711,7 @@ bool ConvexifyFace(
 	}
 /*
 	char szFile[20];
-	sprintf(szFile, "log%06i.txt", iFace);
+	snprintf(szFile, 20, "log%06i.txt", iFace);
 	FILE * fp = fopen(szFile, "w");
 	for(int i=0; i<nNodes; ++i) {
 		const Node & n = planarNodes[i];
@@ -3049,7 +3049,7 @@ void ConvexifyMesh(
 	int nFaces = mesh.faces.size();
 	for (int f = 0; f < nFaces; f++) {
 		if (fVerbose) {
-			sprintf(szBuffer, "Face %i", f);
+			snprintf(szBuffer, 256, "Face %i", f);
 			AnnounceStartBlock(szBuffer);
 		}
 
@@ -3089,7 +3089,7 @@ void ConvexifyMesh(
 	int nFaces = mesh.faces.size();
 	for (int f = 0; f < nFaces; f++) {
 		if (fVerbose) {
-			sprintf(szBuffer, "Face %i", f);
+			snprintf(szBuffer, 256, "Face %i", f);
 			AnnounceStartBlock(szBuffer);
 		}
 

--- a/src/OfflineMap.cpp
+++ b/src/OfflineMap.cpp
@@ -2510,12 +2510,12 @@ void OfflineMap::Read(
 
 	for (int i = 0; i < nSrcGridDims; i++) {
 		char szDim[64];
-		sprintf(szDim, "name%i", nSrcGridDims - i - 1);
+		snprintf(szDim, 64, "name%i", nSrcGridDims - i - 1);
 		NcAtt * attDim = varSrcGridDims->get_att(szDim);
 		if (attDim != NULL) {
 			m_vecSourceDimNames[i] = attDim->as_string(0);
 		} else {
-			sprintf(szDim, "dim%i", nSrcGridDims - i - 1);
+			snprintf(szDim, 64, "dim%i", nSrcGridDims - i - 1);
 			m_vecSourceDimNames[i] = szDim;
 		}
 	}
@@ -2528,12 +2528,12 @@ void OfflineMap::Read(
 
 	for (int i = 0; i < nDstGridDims; i++) {
 		char szDim[64];
-		sprintf(szDim, "name%i", nDstGridDims - i - 1);
+		snprintf(szDim, 64, "name%i", nDstGridDims - i - 1);
 		NcAtt * attDim = varDstGridDims->get_att(szDim);
 		if (attDim != NULL) {
 			m_vecTargetDimNames[i] = attDim->as_string(0);
 		} else {
-			sprintf(szDim, "dim%i", nDstGridDims - i - 1);
+			snprintf(szDim, 64, "dim%i", nDstGridDims - i - 1);
 			m_vecTargetDimNames[i] = szDim;
 		}
 	}
@@ -2814,7 +2814,7 @@ void OfflineMap::Write(
 		}
 
 		for (int i = 0; i < m_vecSourceDimSizes.size(); i++) {
-			sprintf(szDim, "name%i", i);
+			snprintf(szDim, 64, "name%i", i);
 			varSrcGridDims->add_att(szDim,
 				m_vecSourceDimNames[nSrcGridDims - i - 1].c_str());
 		}
@@ -2831,7 +2831,7 @@ void OfflineMap::Write(
 		}
 
 		for (int i = 0; i < m_vecTargetDimSizes.size(); i++) {
-			sprintf(szDim, "name%i", i);
+			snprintf(szDim, 64, "name%i", i);
 			varDstGridDims->add_att(szDim,
 				m_vecTargetDimNames[nDstGridDims - i - 1].c_str());
 		}
@@ -3675,10 +3675,10 @@ bool OfflineMap::CheckMap(
 					strHistogram += ",";
 				}
 				if (i == nHistogramRows.GetRows()-1) {
-					sprintf(szBuffer, "[%i, %i, %i]",
+					snprintf(szBuffer, 128, "[%i, %i, %i]",
 						i, nHistogramCols[i], nHistogramRows[i]);
 				} else {
-					sprintf(szBuffer, "[%i, %i, %i]",
+					snprintf(szBuffer, 128, "[%i, %i, %i]",
 						i, nHistogramCols[i], nHistogramRows[i]);
 				}
 				strHistogram += szBuffer;
@@ -3694,49 +3694,49 @@ bool OfflineMap::CheckMap(
 		Announce("..Column 3: # of weights in that bin");
 		strHistogram = "[";
 		if (nHistogramWeights[0] != 0) {
-			sprintf(szBuffer, "[-inf, -10, %i]", nHistogramWeights[0]);
+			snprintf(szBuffer, 128, "[-inf, -10, %i]", nHistogramWeights[0]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[1] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[-10, -1, %i]", nHistogramWeights[1]);
+			snprintf(szBuffer, 128, "[-10, -1, %i]", nHistogramWeights[1]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[2] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[-1, 0, %i]", nHistogramWeights[2]);
+			snprintf(szBuffer, 128, "[-1, 0, %i]", nHistogramWeights[2]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[3] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[0, 1, %i]", nHistogramWeights[3]);
+			snprintf(szBuffer, 128, "[0, 1, %i]", nHistogramWeights[3]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[4] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[1, 2, %i]", nHistogramWeights[4]);
+			snprintf(szBuffer, 128, "[1, 2, %i]", nHistogramWeights[4]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[5] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[2, 10, %i]", nHistogramWeights[5]);
+			snprintf(szBuffer, 128, "[2, 10, %i]", nHistogramWeights[5]);
 			strHistogram += szBuffer;
 		}
 		if (nHistogramWeights[6] != 0) {
 			if (strHistogram.length() != 1) {
 				strHistogram += ",";
 			}
-			sprintf(szBuffer, "[10, inf, %i]", nHistogramWeights[6]);
+			snprintf(szBuffer, 128, "[10, inf, %i]", nHistogramWeights[6]);
 			strHistogram += szBuffer;
 		}
 		strHistogram += "]";

--- a/src/OfflineMap.h
+++ b/src/OfflineMap.h
@@ -131,8 +131,6 @@ public:
         const std::vector<int>& p_tgtDimSizes
     );
 
-protected:
-
 	///	<summary>
 	///		Clip and assured sum function.
 	///	</summary>
@@ -141,6 +139,8 @@ protected:
 		DataArray1D<double> & dataLowerBound,
 		DataArray1D<double> & dataUpperBound,
 		double & dMass);
+
+protected:
 
 	///	<summary>
 	///		Initialize the coordinate arrays for a finite-volume mesh.

--- a/src/ShpToMesh.cpp
+++ b/src/ShpToMesh.cpp
@@ -233,7 +233,7 @@ try {
 		}
 
 		char szBuffer[128];
-		sprintf(szBuffer, "Polygon %i", shprechead.iNumber);
+		snprintf(szBuffer, 128, "Polygon %i", shprechead.iNumber);
 		iPolygonIx++;
 		AnnounceStartBlock(szBuffer);
 


### PR DESCRIPTION
Fix several sprintf->snprintf and vsprintf->vsnprintf deprecation warnings when build the source repo on Mac OSX with clang 14+.