### PR TITLE
Remove overlap mesh requirement for bilin and delaunay methods

### DIFF
--- a/src/GridElements.h
+++ b/src/GridElements.h
@@ -721,7 +721,9 @@ public:
 	///		Constructor with input mesh parameter.
 	///	</summary>
 	Mesh(const std::string & strFile) {
-		Read(strFile);
+		if (strFile != "") {
+			Read(strFile);
+		}
 	}
 
 public:


### PR DESCRIPTION
The overlap mesh isn't used for bilinear or delaunay maps. This PR removes the requirement that ov_mesh be specified on the GenerateOverlapMesh command line for these cases.