### PR TITLE
Updates to build cleanly on NERSC:Perlmutter

### DIFF
--- a/.github/workflows/conda_ubuntu_osx.yml
+++ b/.github/workflows/conda_ubuntu_osx.yml
@@ -74,9 +74,10 @@ jobs:
       run: |
         pwd
         export DYLD_LIBRARY_PATH=/Users/runner/miniconda3/envs/test-environment/lib:$DYLD_LIBRARY_PATH
+        export PATH=/Users/runner/miniconda3/envs/test-environment/bin:$PATH
         which python
         ls -ltrh
-        which autoreconf
+        which ncdump h5dump autoreconf
         autoreconf -fi
         ./configure --prefix=$HOME/tr_install --with-netcdf=/Users/runner/miniconda3/envs/test-environment --with-hdf5=/Users/runner/miniconda3/envs/test-environment --with-netcdf-include=/Users/runner/miniconda3/envs/test-environment/include --with-netcdf-lib=/Users/runner/miniconda3/envs/test-environment/lib 
         make -j
@@ -86,8 +87,8 @@ jobs:
       run: |
         pwd
         echo $HOME
-        # ls -ltrh /Users/runner/miniconda3/envs/test-environment/lib/
         export DYLD_LIBRARY_PATH=/Users/runner/miniconda3/envs/test-environment/lib:$DYLD_LIBRARY_PATH
+        export PATH=/Users/runner/miniconda3/envs/test-environment/bin:$PATH
         # setting DYLD alone isn't enough, for each executables runtime path to lookup for libraries are required
         install_name_tool -add_rpath '/Users/runner/miniconda3/envs/test-environment/lib/' $HOME/tr_install/bin/GenerateCSMesh
         install_name_tool -add_rpath '@executable_path' $HOME/tr_install/bin/GenerateCSMesh

--- a/config/ax_blas.m4
+++ b/config/ax_blas.m4
@@ -165,13 +165,13 @@ if test $ax_blas_ok = no; then
 		# 64-bit
 		if test $host_cpu = x86_64; then
 			AC_CHECK_LIB(mkl_intel_lp64, $sgemm,
-				[ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread"],,
-				[-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread])
+				[ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -limf -lpthread"],,
+				[-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -limf -lpthread])
 		# 32-bit
 		elif test $host_cpu = i686; then
 			AC_CHECK_LIB(mkl_intel, $sgemm,
-				[ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel -lmkl_sequential -lmkl_core -lpthread"],,
-				[-lmkl_intel -lmkl_sequential -lmkl_core -lpthread])
+				[ax_blas_ok=yes;BLAS_LIBS="-lmkl_intel -lmkl_sequential -lmkl_core -limf -lpthread"],,
+				[-lmkl_intel -lmkl_sequential -lmkl_core -limf -lpthread])
 		fi
 	fi
 fi

--- a/config/ax_lapack.m4
+++ b/config/ax_lapack.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#         http://www.gnu.org/software/autoconf-archive/ax_lapack.html
+#        https://www.gnu.org/software/autoconf-archive/ax_lapack.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -37,6 +37,7 @@
 # LICENSE
 #
 #   Copyright (c) 2009 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2019 Geoffrey M. Oxberry <goxberry@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -49,7 +50,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -64,7 +65,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 7
+#serial 10
 
 AU_ALIAS([ACX_LAPACK], [AX_LAPACK])
 AC_DEFUN([AX_LAPACK], [
@@ -76,21 +77,14 @@ AC_ARG_WITH(lapack,
 case $with_lapack in
         yes | "") ;;
         no) ax_lapack_ok=disable ;;
-        -* | */* | *.a | *.so | *.so.* | *.o) LAPACK_LIBS="$with_lapack" ;;
+        -* | */* | *.a | *.so | *.so.* | *.dylib | *.dylib.* | *.o)
+                 LAPACK_LIBS="$with_lapack"
+        ;;
         *) LAPACK_LIBS="-l$with_lapack" ;;
 esac
-DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --with-lapack=$with_lapack"
 
 # Get fortran linker name of LAPACK function to check for.
-if (test "x$ax_blas_underscore" != "xyes"); then
-  cheev="cheev"
-else
-  if (test "x$ax_blas_underscore" != "xyes2"); then
-    cheev="cheev_"
-  else
-    cheev="cheev__"
-  fi
-fi
+AC_F77_FUNC(cheev)
 
 # We cannot use LAPACK if BLAS is not found
 if test "x$ax_blas_ok" != xyes; then
@@ -102,7 +96,7 @@ fi
 if test "x$LAPACK_LIBS" != x; then
         save_LIBS="$LIBS"; LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS $FLIBS"
         AC_MSG_CHECKING([for $cheev in $LAPACK_LIBS])
-        AC_TRY_LINK_FUNC($cheev, [ax_lapack_ok=yes], [LAPACK_LIBS=""])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [$cheev])], [ax_lapack_ok=yes], [LAPACK_LIBS=""])
         AC_MSG_RESULT($ax_lapack_ok)
         LIBS="$save_LIBS"
         if test $ax_lapack_ok = no; then
@@ -138,4 +132,3 @@ else
         $2
 fi
 ])dnl AX_LAPACK
-

--- a/config/ax_lapack.m4
+++ b/config/ax_lapack.m4
@@ -84,7 +84,8 @@ case $with_lapack in
 esac
 
 # Get fortran linker name of LAPACK function to check for.
-AC_F77_FUNC(cheev)
+#AC_F77_FUNC(dgeev)
+#dgeev="dgeev DGEEV dgeev_ dgeev__ _dgeev DGEEV_ _DGEEV"
 
 # We cannot use LAPACK if BLAS is not found
 if test "x$ax_blas_ok" != xyes; then
@@ -95,8 +96,8 @@ fi
 # First, check LAPACK_LIBS environment variable
 if test "x$LAPACK_LIBS" != x; then
         save_LIBS="$LIBS"; LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS $FLIBS"
-        AC_MSG_CHECKING([for $cheev in $LAPACK_LIBS])
-        AC_LINK_IFELSE([AC_LANG_CALL([], [$cheev])], [ax_lapack_ok=yes], [LAPACK_LIBS=""])
+        AC_MSG_CHECKING([for $dgeev in $LAPACK_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [$dgeev])], [ax_lapack_ok=yes], [LAPACK_LIBS=""])
         AC_MSG_RESULT($ax_lapack_ok)
         LIBS="$save_LIBS"
         if test $ax_lapack_ok = no; then
@@ -107,7 +108,7 @@ fi
 # LAPACK linked to by default?  (is sometimes included in BLAS lib)
 if test $ax_lapack_ok = no; then
         save_LIBS="$LIBS"; LIBS="$LIBS $BLAS_LIBS $FLIBS"
-        AC_CHECK_FUNC($cheev, [ax_lapack_ok=yes])
+        AC_CHECK_FUNC($dgeev, [ax_lapack_ok=yes])
         LIBS="$save_LIBS"
 fi
 
@@ -115,7 +116,7 @@ fi
 for lapack in lapack lapack_rs6k; do
         if test $ax_lapack_ok = no; then
                 save_LIBS="$LIBS"; LIBS="$BLAS_LIBS $LIBS"
-                AC_CHECK_LIB($lapack, $cheev,
+                AC_CHECK_LIB($lapack, $dgeev,
                     [ax_lapack_ok=yes; LAPACK_LIBS="-l$lapack"], [], [$FLIBS])
                 LIBS="$save_LIBS"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,12 @@ DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS CC=$CC CXX=$CXX FC=$FC"
 AX_CXX_COMPILE_STDCXX([11], [], [mandatory])
 
 ## Checks for some standard libraries.
-#AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
-#AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
+AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
+if (test "$cxx_compiler" != "Intel"); then
+  AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
+fi
+
+m4_defun([_LT_AC_LANG_F77_CONFIG], [:])
 
 # Checks for BLAS/LAPACK libraries:
 AX_BLAS([], [AC_MSG_ERROR([BLAS library not found])])

--- a/configure.ac
+++ b/configure.ac
@@ -27,9 +27,9 @@ DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS CC=$CC CXX=$CXX FC=$FC"
 # TODO: Should we check for partial C++11 support also ?
 AX_CXX_COMPILE_STDCXX([11], [], [mandatory])
 
-# Checks for some standard libraries.
-AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
-AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
+## Checks for some standard libraries.
+#AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
+#AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
 
 # Checks for BLAS/LAPACK libraries:
 AX_BLAS([], [AC_MSG_ERROR([BLAS library not found])])
@@ -41,7 +41,6 @@ ACX_NETCDF([],[AC_MSG_ERROR(cannot find NetCDF library. Please specify the direc
 AC_LANG_POP([C++])
 
 # Checks for header files.
-AC_CHECK_HEADERS([malloc.h stdlib.h string.h unistd.h])
 AC_CHECK_HEADER(unordered_map, [AC_DEFINE([OVERLAPMESH_USE_UNSORTED_MAP], [1], [Use unordered maps in Overlap mesh],[])])
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -55,7 +54,7 @@ AC_TYPE_UINT64_T
 AC_FUNC_ALLOCA
 AC_FUNC_ERROR_AT_LINE
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([memset pow sqrt])
+AC_CHECK_FUNCS([memset])
 
 AC_SUBST(DISTCHECK_CONFIGURE_FLAGS)
 AC_CONFIG_FILES([Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -3,28 +3,25 @@
 # Usage: autoreconf -fi
 #
 AC_PREREQ([2.69])
-AC_INIT([TempestRemap],[2.1.2],[paullrich@ucdavis.edu])
+AC_INIT([TempestRemap],[2.2.0],[paullrich@ucdavis.edu])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 #AC_CONFIG_SRCDIR([test/optimtest.m])
 AC_CONFIG_HEADERS([src/TempestConfig.h])
 
 AM_INIT_AUTOMAKE([foreign subdir-objects])
-LT_INIT
 AM_SILENT_RULES([yes])
 
 LT_INIT([disable-shared])
 LT_LANG([C++])
 
 # Checks for programs.
-AC_PROG_CXX([icpc g++])
-AC_PROG_CC([icc gcc])
+AC_PROG_CXX([icpc g++ clang++])
 AC_PROG_MAKE_SET
 
 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS CC=$CC CXX=$CXX FC=$FC"
 
-# Check how to add C++0x flags
-# TODO: Should we check for partial C++11 support also ?
+# Check how to add C++11 flags
 AX_CXX_COMPILE_STDCXX([11], [], [mandatory])
 
 ## Checks for some standard libraries.
@@ -33,7 +30,40 @@ if (test "$cxx_compiler" != "Intel"); then
   AC_CHECK_LIB(m, pow, LIBS="$LIBS -lm")
 fi
 
-m4_defun([_LT_AC_LANG_F77_CONFIG], [:])
+# Let us get the fortran mangling format
+# f: lower-case symbol name
+# F: upper-case symbol name
+# _: prefix or suffix
+FCMANGLE_FORMAT="f_" # GNU, Intel
+AC_ARG_WITH(fc-mangling,
+  [AS_HELP_STRING([--with-fc-mangling=<lib>], [use the provided suffix for Fortran mangled symbols])])
+case $with_fc_mangling in
+  yes | no | "") ;;
+  *) FCMANGLE_FORMAT="$with_fc_mangling" ;;
+esac
+AC_SUBST(FCMANGLE_FORMAT)
+
+daxpy=""
+dgemm=""
+dgeev=""
+len=${#FCMANGLE_FORMAT}
+for(( i=0; i<$len; i++ ))
+do
+  c="${FCMANGLE_FORMAT:i:1}"
+  case $c in 
+    ([[a-z]]) #echo "lowercase letter";
+      daxpy="${daxpy}daxpy";dgemm="${dgemm}dgemm";dgeev="${dgeev}dgeev";;
+    ([[A-Z]]) #echo "uppercase letter";
+      daxpy="${daxpy}DAXPY";dgemm="${dgemm}DGEMM";dgeev="${dgeev}DGEEV";;
+    #([[:alpha:]]) echo neither lower nor uppercase letter;;
+    #([[:digit:]]) echo decimal digit;;
+    ("_") #echo "underscore";
+      daxpy="${daxpy}_";dgemm="${dgemm}_";dgeev="${dgeev}_";;
+    (?);; #echo any other single character;;
+    (*);; #echo something else;;
+  esac
+done
+#echo "daxpy=$daxpy, dgemm=$dgemm, dgeev=$dgeev"
 
 # Checks for BLAS/LAPACK libraries:
 AX_BLAS([], [AC_MSG_ERROR([BLAS library not found])])

--- a/mk/system.make
+++ b/mk/system.make
@@ -12,6 +12,10 @@ ifeq ($(UNAME),Darwin)
   SYSTEM= MACOSX
   SYSTEM_MAKEFILE= macosx.make
 else ifeq ($(UNAME),Linux)
+  ifeq ($(NERSC_HOST),perlmutter)
+    SYSTEM= PERLMUTTER
+    SYSTEM_MAKEFILE= perlmutter.make
+  endif
   ifeq ($(NERSC_HOST),cori)
     SYSTEM= CORI
     SYSTEM_MAKEFILE= cori.make

--- a/mk/system/perlmutter.make
+++ b/mk/system/perlmutter.make
@@ -10,6 +10,7 @@ CXX=               CC
 F90=               ftn
 MPICXX=            CC
 MPIF90=            ftn
+CXXFLAGS += -MT -MD -MP -MF
 
 # NetCDF
 NETCDF_ROOT=       $(NETCDF_DIR)

--- a/mk/system/perlmutter.make
+++ b/mk/system/perlmutter.make
@@ -1,0 +1,26 @@
+# Copyright (c) 2016      Bryce Adelstein-Lelbach aka wash
+# Copyright (c) 2000-2016 Paul Ullrich 
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# NERSC Babbage Testbed
+
+CXX=               CC
+F90=               ftn
+MPICXX=            CC
+MPIF90=            ftn
+
+# NetCDF
+NETCDF_ROOT=       $(NETCDF_DIR)
+NETCDF_CXXFLAGS=   -I$(NETCDF_ROOT)/include
+NETCDF_LIBRARIES=  -lnetcdf
+NETCDF_LDFLAGS=    -L$(NETCDF_ROOT)/lib
+
+# LAPACK (Intel MKL)
+LAPACK_INTERFACE=  FORTRAN
+LAPACK_CXXFLAGS=
+LAPACK_LIBRARIES=
+LAPACK_LDFLAGS=   
+
+# DO NOT DELETE


### PR DESCRIPTION
Several configuration updates to build on Perlmutter with Intel compilers

- Autotools system update
- GNU makefile update with a new machine file